### PR TITLE
Use pkg-config to get include path(s), and export R_HOME.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libR-sys"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["andy-thomason <andy@andythomason.com>"]
 edition = "2018"
 description = "Low level bindings to the R programming language."


### PR DESCRIPTION
(Also bumps version number to support forthcoming PR for extendr).

This should increase the chance of things running out-of-the-box on more platforms.  So far been tested on Fedora Linux + R4.0.2 and MacOS + homebrew + R3.5.

NB. I haven't fully removed the InstallationPaths stuff since it was clearly added for a reason, but this may need some rethinking since it makes assumptions about the relative location of libraries, pkg-config, etc., which are not true on all platforms (e.g. Fedora).