### PR TITLE
Expose R_VERSION number as metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ documentation = "https://extendr.github.io/libR-sys/master/libR_sys/index.html"
 [build-dependencies]
 bindgen = "0.53.2"
 pkg-config = "0.3.17"
-
+regex = "1"

--- a/wrapper.h
+++ b/wrapper.h
@@ -10,3 +10,4 @@
 #include <Rinternals.h>
 #include <Rembedded.h>
 #include <R_ext/Parse.h>
+#include <R_ext/Error.h>

--- a/wrapper.h
+++ b/wrapper.h
@@ -9,5 +9,6 @@
 #include <Rinterface.h>
 #include <Rinternals.h>
 #include <Rembedded.h>
+#include <R/Rversion.h>
 #include <R_ext/Parse.h>
 #include <R_ext/Error.h>


### PR DESCRIPTION
This is a first step towards enabling conditional compilation in extendr for features from recent versions of R.

Work-in-progress extendr side of this is at https://github.com/dasmoth/extendr/commit/c9c9c0534ea2e5bb3053e4ad0a9357e977c8240f.  Current plan is to allow conditional features in the style of:

```rust
    #[cfg(r_version_4_1)]
    pub fn failure() {
        // This is safe since 4.1 isn't out yet...
        Rf_doesNotExist();
    }
```

I'll send a pull request for that once I've had a chance to annotate affected methods on the extendr side.