### PR TITLE
enable easy extraction of created bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libR-sys"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["andy-thomason <andy@andythomason.com>"]
 edition = "2018"
 description = "Low level bindings to the R programming language."

--- a/build.rs
+++ b/build.rs
@@ -114,5 +114,16 @@ fn main() {
 
     bindings
         .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
+        .expect("Couldn't write bindings to default output path!");
+
+    // Also write the bindings to a folder specified by $LIBRSYS_BINDINGS_DIR, if it exists
+
+    if let Ok(alt_target) = env::var("LIBRSYS_BINDINGS_DIR") {
+        let out_path = PathBuf::from(alt_target);
+
+        bindings
+            .write_to_file(out_path.join("bindings.rs"))
+            .expect("Couldn't write bindings to output path specified by $LIBRSYS_BINDINGS_DIR!");
+
+    }
 }


### PR DESCRIPTION
I have patched the build script to also save the bindings to a folder specified by `$LIBRSYS_BINDINGS_DIR`, if it is set. This makes it easy to generate and cache the bindings.