### PR TITLE
use R_HOME if available

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,21 +13,24 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
     if let Ok(r_home) = env::var("R_HOME") {
         // When R_HOME is set, we assume a standard path layout
         let include:String = Path::new(&r_home).join("include").to_str().unwrap().to_string();
+        let pkg_target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
         let library:String = if cfg!(target_os = "windows") {
-            if cfg!(target_arch = "x86_64") {
+            if pkg_target_arch == "x86_64" {
                 Path::new(&r_home)
                     .join("bin")
                     .join("x64")
                     .to_str()
                     .unwrap()
                     .to_string()
-            } else {
+            } else if pkg_target_arch == "x86" {
                 Path::new(&r_home)
                     .join("bin")
                     .join("i386")
                     .to_str()
                     .unwrap()
                     .to_string()
+            } else {
+                panic!("Unknown architecture")
             }
         } else {
             Path::new(&r_home).join("lib").to_str().unwrap().to_string()

--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,21 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
         // When R_HOME is set, we assume a standard path layout
         let include:String = Path::new(&r_home).join("include").to_str().unwrap().to_string();
         let library:String = if cfg!(target_os = "windows") {
-            Path::new(&r_home).join("bin").to_str().unwrap().to_string()
+            if cfg!(target_arch = "x86_64") {
+                Path::new(&r_home)
+                    .join("bin")
+                    .join("x64")
+                    .to_str()
+                    .unwrap()
+                    .to_string()
+            } else {
+                Path::new(&r_home)
+                    .join("bin")
+                    .join("i386")
+                    .to_str()
+                    .unwrap()
+                    .to_string()
+            }
         } else {
             Path::new(&r_home).join("lib").to_str().unwrap().to_string()
         };


### PR DESCRIPTION
When `R_HOME` is set we should just use it rather than try to run R to find it. In fact, when R builds extension packages it explicitly disables running R without a complete path.