### PR TITLE
Clippy and rustc-cfg improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libR-sys"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["andy-thomason <andy@andythomason.com>"]
 edition = "2018"
 description = "Low level bindings to the R programming language."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(improper_ctypes)]
+#![allow(clippy::approx_constant)]
+#![allow(clippy::redundant_static_lifetimes)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 


### PR DESCRIPTION
* Added ignore rules so clippy doesn't complain.
* Added rustc-cfg to pass the binding version to extendr to support building against R 3.x versions.
* Bumped version