### PR TITLE
Improved path setup

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -84,10 +84,6 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
                     .to_string()
             };
 
-            println!("R home: {}", r_home);
-            println!("R library: {}", library);
-            println!("R binary: {}", r_binary);
-
             let out = Command::new(&r_binary)
                 .args(&[
                     "-s",

--- a/build.rs
+++ b/build.rs
@@ -92,10 +92,11 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
                 .args(&[
                     "-s",
                     "-e",
-                    r#"cat(normalizePath(R.home("include")), sep = '\n')"#
+                    r#"cat(normalizePath(R.home('include')), sep = '\n')"#
                 ])
                 .output()?;
 
+            // if there are any errors we print them out, helps with debugging
             for errln in String::from_utf8_lossy(&out.stderr).lines() {
                 println!("> {}", errln);
             }

--- a/build.rs
+++ b/build.rs
@@ -88,7 +88,7 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
             println!("R library: {}", library);
             println!("R binary: {}", r_binary);
 
-            let rout = Command::new(&r_binary)
+            let out = Command::new(&r_binary)
                 .args(&[
                     "-s",
                     "-e",
@@ -96,11 +96,12 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
                 ])
                 .output()?;
 
-            let rout = String::from_utf8_lossy(&rout.stdout);
+            for errln in String::from_utf8_lossy(&out.stderr).lines() {
+                println!("> {}", errln);
+            }
+
+            let rout = String::from_utf8_lossy(&out.stdout);
             let mut lines = rout.lines();
-
-            println!("R output: {:?}", lines);
-
             match lines.next() {
                 Some(line) => line.to_string(),
                 _ => return Err(Error::new(ErrorKind::Other, "Cannot find R include.")),

--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,18 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
         }
     };
 
+    let rout = Command::new("R")
+        .args(&[
+            "-s",
+            "-e",
+            r#"cat(normalizePath(R.home()), normalizePath(R.home("include")), normalizePath(R.home("lib")), sep = '\n')"#
+        ])
+        .output()?;
+    println!("{}", String::from_utf8_lossy(&rout.stdout));
+    println!("{}", env::var("R_HOME").unwrap_or_default());
+    println!("{}", env::var("R_INCLUDE_DIR").unwrap_or_default());
+
+
     // For include and lib, assume a standard path layout
     // Note that on Windows, this depends on the target architecture
     let include:String = Path::new(&r_home).join("include").to_str().unwrap().to_string();

--- a/build.rs
+++ b/build.rs
@@ -61,12 +61,6 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
         Path::new(&r_home).join("lib").to_str().unwrap().to_string()
     };
 
-    let bin = /*if cfg!(target_os = "windows") {
-        library.clone()
-    } else {*/
-        Path::new(&r_home).join("bin").to_str().unwrap().to_string();
-    //};
-
     // Finally the include location. It may or may not be located under R home
     let include = match env::var("R_INCLUDE_DIR") {
         // If the environment variable R_INCLUDE_DIR is set we use it
@@ -74,8 +68,20 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
 
         // Otherwise, we try to execute `R` to find the include dir.
         _ => {
-            let r_binary= Path::new(&bin)
-                .join("R").to_str().unwrap().to_string();
+            let r_binary = if cfg!(target_os = "windows") {
+                Path::new(&library)
+                    .join("R.exe")
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+            } else {
+                Path::new(&r_home)
+                    .join("bin")
+                    .join("R")
+                    .to_str()
+                    .unwrap()
+                    .to_string();
+            };
 
             let rout = Command::new(&r_binary)
                 .args(&[

--- a/build.rs
+++ b/build.rs
@@ -84,6 +84,10 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
                     .to_string()
             };
 
+            println!("R home: {}", r_home);
+            println!("R library: {}", library);
+            println!("R binary: {}", r_binary);
+
             let rout = Command::new(&r_binary)
                 .args(&[
                     "-s",

--- a/build.rs
+++ b/build.rs
@@ -39,7 +39,7 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
 
     // Now the library location. On Windows, it depends on the target architecture
     let pkg_target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let library:String = if cfg!(target_os = "windows") {
+    let library = if cfg!(target_os = "windows") {
         if pkg_target_arch == "x86_64" {
             Path::new(&r_home)
                 .join("bin")
@@ -61,6 +61,12 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
         Path::new(&r_home).join("lib").to_str().unwrap().to_string()
     };
 
+    let bin = if cfg!(target_os = "windows") {
+        library.clone()
+    } else {
+        Path::new(&r_home).join("bin").to_str().unwrap().to_string()
+    };
+
     // Finally the include location. It may or may not be located under R home
     let include = match env::var("R_INCLUDE_DIR") {
         // If the environment variable R_INCLUDE_DIR is set we use it
@@ -68,7 +74,7 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
 
         // Otherwise, we try to execute `R` to find the include dir.
         _ => {
-            let r_binary= Path::new(&r_home)
+            let r_binary= Path::new(&bin)
                 .join("R").to_str().unwrap().to_string();
 
             let rout = Command::new(&r_binary)

--- a/build.rs
+++ b/build.rs
@@ -66,21 +66,22 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
         // If the environment variable R_INCLUDE_DIR is set we use it
         Ok(s) => s,
 
-        // Otherwise, we try to execute `R` to find the include dir.
+        // Otherwise, we try to execute `R` to find the include dir. Here,
+        // we're using the R home we found earlier, to make sure we're consistent.
         _ => {
             let r_binary = if cfg!(target_os = "windows") {
                 Path::new(&library)
                     .join("R.exe")
                     .to_str()
                     .unwrap()
-                    .to_string();
+                    .to_string()
             } else {
                 Path::new(&r_home)
                     .join("bin")
                     .join("R")
                     .to_str()
                     .unwrap()
-                    .to_string();
+                    .to_string()
             };
 
             let rout = Command::new(&r_binary)

--- a/build.rs
+++ b/build.rs
@@ -61,11 +61,11 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
         Path::new(&r_home).join("lib").to_str().unwrap().to_string()
     };
 
-    let bin = if cfg!(target_os = "windows") {
+    let bin = /*if cfg!(target_os = "windows") {
         library.clone()
-    } else {
-        Path::new(&r_home).join("bin").to_str().unwrap().to_string()
-    };
+    } else {*/
+        Path::new(&r_home).join("bin").to_str().unwrap().to_string();
+    //};
 
     // Finally the include location. It may or may not be located under R home
     let include = match env::var("R_INCLUDE_DIR") {

--- a/build.rs
+++ b/build.rs
@@ -99,6 +99,8 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
             let rout = String::from_utf8_lossy(&rout.stdout);
             let mut lines = rout.lines();
 
+            println!("R output: {:?}", lines);
+
             match lines.next() {
                 Some(line) => line.to_string(),
                 _ => return Err(Error::new(ErrorKind::Other, "Cannot find R include.")),


### PR DESCRIPTION
The reworked code only tries to find the top-level R folder and then assumes a standard directory structure underneath. This should fix some problems on Windows.