### PR TITLE
WIP: Add separate Windows i686 build to GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,3 +88,39 @@ jobs:
           cargo test -- --nocapture --test-threads=1
         env:
           LIBCLANG_PATH: C:/msys64/mingw64/bin
+
+  test_windows_i686:
+    name: Run tests (Windows i686)
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      matrix:
+        rust-version: [stable-i686-pc-windows-gnu]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW32
+          path-type: inherit
+          release: false
+          update: false
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: 'release'
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust-version }}
+          default: true
+          components: rustfmt, clippy
+      - name: Build
+        run: |
+          cargo build -vv
+        env:
+          LIBCLANG_PATH: C:/msys64/mingw32/bin
+      - name: Run tests
+        run: |
+          cargo test -- --nocapture --test-threads=1
+        env:
+          LIBCLANG_PATH: C:/msys64/mingw32/bin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,10 @@ jobs:
           components: rustfmt, clippy
       - name: Build
         run: |
+          ls C:/rtools40/mingw64/bin
+          ls -al C:/msys64/mingw64/bin/libclang.dll
+          rm -rf C:/msys64/mingw64/bin/libclang.dll
+          ls -al C:/msys64/mingw64/bin/libclang.dll
           cargo build --release -vv
         env:
           R_HOME: C:\\R

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,8 @@ jobs:
         run: |
           cargo build -vv
         env:
+          C:/msys64/mingw32/bin/llvm-config.exe --includedir
+          llvm-config --includedir
           #LIBCLANG_PATH: C:/msys64/mingw32/bin
           LLVM_CONFIG_PATH: C:/msys64/mingw32/bin/llvm-config.exe
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,8 @@ jobs:
         run: |
           cargo build -vv
         env:
-          LIBCLANG_PATH: C:/msys64/mingw32/bin
+          #LIBCLANG_PATH: C:/msys64/mingw32/bin
+          LLVM_CONFIG_PATH: C:/msys64/mingw32/bin/llvm-config.exe
       - name: Run tests
         run: |
           cargo test -- --nocapture --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,10 +118,10 @@ jobs:
           components: rustfmt, clippy
       - name: Build
         run: |
-          cargo build -vv
-        env:
           C:/msys64/mingw32/bin/llvm-config.exe --includedir
           llvm-config --includedir
+          cargo build -vv
+        env:
           #LIBCLANG_PATH: C:/msys64/mingw32/bin
           LLVM_CONFIG_PATH: C:/msys64/mingw32/bin/llvm-config.exe
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Install R
         run: |
           curl.exe -o D:/a/_temp/Rinstall.exe https://cran.r-project.org/bin/windows/base/R-4.0.3-win.exe
-          D:/a/_temp/Rinstall.exe /SUPPRESSMSGBOXES /DIR=C:\R
+          D:/a/_temp/Rinstall.exe /SUPPRESSMSGBOXES /DIR=C:\\R
 #      - uses: r-lib/actions/setup-r@v1
 #        with:
 #          r-version: 'release'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           curl.exe -o D:/a/_temp/Rinstall.exe https://cran.r-project.org/bin/windows/base/R-4.0.3-win.exe
           ls -al D:/a/_temp/Rinstall.exe 
-          D:/a/_temp/Rinstall.exe /SUPPRESSMSGBOXES /DIR=C:\\R
+          D:/a/_temp/Rinstall.exe /SILENT /SUPPRESSMSGBOXES /DIR=C:\\R
 #      - uses: r-lib/actions/setup-r@v1
 #        with:
 #          r-version: 'release'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,10 +123,8 @@ jobs:
           components: rustfmt, clippy
       - name: Build
         run: |
-          ls C:/rtools40/mingw64/bin
           ls -al C:/msys64/mingw64/bin/libclang.dll
           rm -rf C:/msys64/mingw64/bin/libclang.dll
-          ls -al C:/msys64/mingw64/bin/libclang.dll
           cargo build --release -vv
         env:
           R_HOME: C:\\R

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,14 @@ jobs:
         rust-version: [stable-i686-pc-windows-gnu]
     steps:
       - uses: actions/checkout@v2
+#      - name: Install R
+#        run: |
+#          curl.exe -o D:/a/_temp/Rinstall.exe https://cran.r-project.org/bin/windows/base/R-4.0.3-win.exe
+#          ls -al D:/a/_temp/Rinstall.exe 
+#          D:/a/_temp/Rinstall.exe /SILENT /SUPPRESSMSGBOXES /DIR=C:\\R
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: 'release'
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW32
@@ -108,14 +116,6 @@ jobs:
           update: false
           install: >-
             mingw-w64-i686-clang
-      - name: Install R
-        run: |
-          curl.exe -o D:/a/_temp/Rinstall.exe https://cran.r-project.org/bin/windows/base/R-4.0.3-win.exe
-          ls -al D:/a/_temp/Rinstall.exe 
-          D:/a/_temp/Rinstall.exe /SILENT /SUPPRESSMSGBOXES /DIR=C:\\R
-#      - uses: r-lib/actions/setup-r@v1
-#        with:
-#          r-version: 'release'
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust-version }}
@@ -125,7 +125,7 @@ jobs:
         run: |
           cargo build -vv
         env:
-          R_HOME: C:\R
+          R_HOME: C:\\R
           LLVM_CONFIG_PATH: C:/msys64/mingw32/bin/llvm-config.exe
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,8 @@ jobs:
           path-type: inherit
           release: false
           update: false
+          install: >-
+            mingw-w64-i686-clang
       - uses: r-lib/actions/setup-r@v1
         with:
           r-version: 'release'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW32
-          path-type: inherit
+          path-type: minimal
           release: false
           update: false
           install: >-
@@ -118,11 +118,9 @@ jobs:
           components: rustfmt, clippy
       - name: Build
         run: |
-          C:/msys64/mingw32/bin/llvm-config.exe --includedir
-          llvm-config --includedir
           cargo build -vv
         env:
-          #LIBCLANG_PATH: C:/msys64/mingw32/bin
+          R_HOME: C:\R
           LLVM_CONFIG_PATH: C:/msys64/mingw32/bin/llvm-config.exe
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
           components: rustfmt, clippy
       - name: Build
         run: |
-          cargo build -vv
+          cargo build --release -vv
         env:
           R_HOME: C:\\R
           LLVM_CONFIG_PATH: C:/msys64/mingw32/bin/llvm-config.exe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,13 +70,9 @@ jobs:
           path-type: inherit
           release: false
           update: false
-      - name: Install R
-        run: |
-          curl.exe -o D:\a\_temp\Rinstall.exe https://cran.r-project.org/bin/windows/base/R-4.0.3-win.exe
-          D:\a\_temp\Rinstall.exe /SUPPRESSMSGBOXES /DIR=C:\R
-#      - uses: r-lib/actions/setup-r@v1
-#        with:
-#          r-version: 'release'
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: 'release'
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust-version }}
@@ -112,9 +108,13 @@ jobs:
           update: false
           install: >-
             mingw-w64-i686-clang
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: 'release'
+      - name: Install R
+        run: |
+          curl.exe -o D:/a/_temp/Rinstall.exe https://cran.r-project.org/bin/windows/base/R-4.0.3-win.exe
+          D:/a/_temp/Rinstall.exe /SUPPRESSMSGBOXES /DIR=C:\R
+#      - uses: r-lib/actions/setup-r@v1
+#        with:
+#          r-version: 'release'
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,14 +100,6 @@ jobs:
         rust-version: [stable-i686-pc-windows-gnu]
     steps:
       - uses: actions/checkout@v2
-#      - name: Install R
-#        run: |
-#          curl.exe -o D:/a/_temp/Rinstall.exe https://cran.r-project.org/bin/windows/base/R-4.0.3-win.exe
-#          ls -al D:/a/_temp/Rinstall.exe 
-#          D:/a/_temp/Rinstall.exe /SILENT /SUPPRESSMSGBOXES /DIR=C:\\R
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: 'release'
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW32
@@ -116,6 +108,9 @@ jobs:
           update: false
           install: >-
             mingw-w64-i686-clang
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: 'release'
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust-version }}
@@ -123,8 +118,6 @@ jobs:
           components: rustfmt, clippy
       - name: Build
         run: |
-          ls -al C:/msys64/mingw64/bin/libclang.dll
-          rm -rf C:/msys64/mingw64/bin/libclang.dll
           cargo build --release -vv
         env:
           R_HOME: C:\\R

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,9 +70,13 @@ jobs:
           path-type: inherit
           release: false
           update: false
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: 'release'
+      - name: Install R
+        run: |
+          curl.exe -o D:\a\_temp\Rinstall.exe https://cran.r-project.org/bin/windows/base/R-4.0.3-win.exe
+          D:\a\_temp\Rinstall.exe /SUPPRESSMSGBOXES /DIR=C:\R
+#      - uses: r-lib/actions/setup-r@v1
+#        with:
+#          r-version: 'release'
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW32
-          path-type: minimal
+          path-type: inherit
           release: false
           update: false
           install: >-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,7 @@ jobs:
       - name: Install R
         run: |
           curl.exe -o D:/a/_temp/Rinstall.exe https://cran.r-project.org/bin/windows/base/R-4.0.3-win.exe
+          ls -al D:/a/_temp/Rinstall.exe 
           D:/a/_temp/Rinstall.exe /SUPPRESSMSGBOXES /DIR=C:\\R
 #      - uses: r-lib/actions/setup-r@v1
 #        with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,8 @@ jobs:
           components: rustfmt, clippy
       - name: Build
         run: |
+          llvm-config --version
+          cargo --version
           cargo build -vv
         env:
           LIBCLANG_PATH: C:/msys64/mingw64/bin
@@ -118,6 +120,8 @@ jobs:
           components: rustfmt, clippy
       - name: Build
         run: |
+          llvm-config --version
+          cargo --version
           cargo build --release -vv
         env:
           R_HOME: C:\\R


### PR DESCRIPTION
This PR adds a separate Windows i686 GH action runner. I think our first goal should be to get it working in a separate runner, and then we can think of combining all Windows tests into one.

This is a continuation of #23.