### PR TITLE
Remove kernel32-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,4 @@ regex = { version = "1", optional = true }
 use-bindgen = ["bindgen", "regex"]
 
 [target.'cfg(windows)'.build-dependencies]
-winapi = "0.3"
-kernel32-sys = "0.2.2"
+winapi = { version = "0.3", features = ["consoleapi", "stringapiset"] }

--- a/build.rs
+++ b/build.rs
@@ -51,10 +51,10 @@ fn wide_from_console_string(bytes: &[u8]) -> Vec<u16> {
     let mut wide;
     let mut len;
     unsafe {
-        let cp = kernel32::GetConsoleCP();
-        len = kernel32::MultiByteToWideChar(cp, 0, bytes.as_ptr() as *const i8, bytes.len() as i32, std::ptr::null_mut(), 0);
+        let cp = winapi::um::consoleapi::GetConsoleCP();
+        len = winapi::um::stringapiset::MultiByteToWideChar(cp, 0, bytes.as_ptr() as *const i8, bytes.len() as i32, std::ptr::null_mut(), 0);
         wide = Vec::with_capacity(len as usize);
-        len = kernel32::MultiByteToWideChar(cp, 0, bytes.as_ptr() as *const i8, bytes.len() as i32, wide.as_mut_ptr(), len);
+        len = winapi::um::stringapiset::MultiByteToWideChar(cp, 0, bytes.as_ptr() as *const i8, bytes.len() as i32, wide.as_mut_ptr(), len);
         wide.set_len(len as usize);
     }
     wide


### PR DESCRIPTION
Just happened to find this. winapi's README says:

> Should I still use those -sys crates such as kernel32-sys?
> 
> No. Those crates are a legacy of how winapi 0.2 was organized. Starting with winapi 0.3 all definitions are directly in winapi itself, and so there is no longer any need to use those -sys crates.

So I guess we only need to use winapi, right? (I didn't even know winapi is a successor of kernel32-sys until today...)