### PR TITLE
Using `ci-cargo` from `extendr`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,18 +263,13 @@ jobs:
       # Run tests again using different bindings
       - name: Run tests on precomputed bindings shipped with libR-sys
         run: |
+          . ./ci-cargo.ps1
           foreach ($target in ($env:RUST_TARGETS).Split(",")) {
             if(($env:NO_TEST_TARGETS).Split(",").Contains($target)) {
               echo "::warning:: Skipping tests for target: $target"
             }
             else {            
-              echo "::group::Running tests for target: $target"
-              cargo test -vv $(if ($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1
-              if (!$?) { 
-                echo "::error::Running tests for target: $target";
-                throw "Last exit code $LASTEXITCODE"
-              }
-              echo "::endgroup::"
+              ci-cargo test -vv $(if ($target -ne 'default') {"--target=$target"} ) '--' --nocapture --test-threads=1 -ActionName "Running tests for target: $target"
             }
           }
         env: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - master
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - master
+      - 'ci-cargo'
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,18 +146,13 @@ jobs:
       - name: Run tests
         id: test
         run: |
+          . ./ci-cargo.ps1
           foreach ($target in ($env:RUST_TARGETS).Split(",")) {
             if(($env:NO_TEST_TARGETS).Split(",").Contains($target)) {
               echo "::warning:: Skipping bindgen tests for target: $target"
             }
             else {
-              echo "::group::Running bindgen tests for target: $target"
-              cargo test -vv --features use-bindgen $(if ($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1
-              if (!$?) { 
-                echo "::error::Running bindgen tests for target: $target";
-                throw "Last exit code $LASTEXITCODE"
-              }
-              echo "::endgroup::"
+              ci-cargo test -vv --features use-bindgen $(if ($target -ne 'default') {"--target=$target"} ) '--' --nocapture --test-threads=1 -ActionName "Running bindgen tests for target: $target"
             }
           }
         env: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - master
-      - 'ci-cargo'
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,18 +178,13 @@ jobs:
       # Run tests again using different bindings
       - name: Run tests on precomputed bindings shipped with libR-sys
         run: |
+          . ./ci-cargo.ps1
           foreach ($target in ($env:RUST_TARGETS).Split(",")) {
             if(($env:NO_TEST_TARGETS).Split(",").Contains($target)) {
               echo "::warning:: Skipping tests for target: $target"
             }
-            else {            
-              echo "::group::Running tests for target: $target"
-              cargo test -vv $(if ($target -ne 'default') {"--target=$target"} ) -- --nocapture --test-threads=1
-              if (!$?) { 
-                echo "::error::Running tests for target: $target";
-                throw "Last exit code $LASTEXITCODE"
-              }
-              echo "::endgroup::"
+            else {    
+              ci-cargo test -vv $(if ($target -ne 'default') {"--target=$target"} ) '--' --nocapture --test-threads=1 -ActionName "Running tests for target: $target"
             }
           }
         env: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,14 +135,9 @@ jobs:
       - name: Build & Emit bindings
         id: build
         run: |
+          . ./ci-cargo.ps1
           foreach ($target in ($env:RUST_TARGETS).Split(",")) {
-            echo "::group::Building for target: $target"
-            cargo build -vv --features use-bindgen $(if ($target -ne 'default') {"--target=$target"} )
-            if (!$?) { 
-              echo "::error::Building for target: $target" ;
-              throw "Last exit code $LASTEXITCODE"
-            }
-            echo "::endgroup::"
+            ci-cargo build -vv --features use-bindgen $(if ($target -ne 'default') {"--target=$target"} ) -ActionName "Building for target: $target"
           }
         env:
           LIBRSYS_BINDINGS_OUTPUT_PATH: generated_bindings

--- a/ci-cargo.ps1
+++ b/ci-cargo.ps1
@@ -1,0 +1,71 @@
+function ci-cargo {
+
+    param(
+        [Parameter(Position = 0, ValueFromRemainingArguments)]
+        [String[]]
+        $CargoArgs,
+        [String]
+        $ActionName
+    )
+
+
+    try {    
+        echo "::group::$ActionName"
+        echo "Running cargo $CargoArgs"
+        cargo $CargoArgs
+        if($LASTEXITCODE -ne  0) {
+            throw $LASTEXITCODE
+        }
+    }
+    catch {
+        if ($ActionName -ne $null -and $ActionName -ne "") {
+            $ActionName = "'$ActionName': "
+        }
+        $err_msg = "$($ActionName)cargo failed with code $LASTEXITCODE (args: $CargoArgs)"
+        echo "::error::$err_msg"
+        Write-Error -Message "$err_msg" -ErrorAction Stop 
+    }
+    finally {
+        echo "::endgroup::"
+    }
+
+    <#
+        .SYNOPSIS
+        Runs cargo with specified args, adapting error handling and output to CI.
+
+        .DESCRIPTION
+        Runs cargo in a `try` block, catches exceptions and non-zero exit codes.
+        Explicitly logs the beginning and the end of cargo execution, as well as the error message.
+
+        .PARAMETER CargoArgs
+        Arguments passed to cargo, as-is.
+        Note that `--` separator is handled by powershell itself,
+        so it should be wrapped in quotes `'--'` and passed as string.
+
+        .PARAMETER ActionName
+        Optional string that is used to format logs and error messages.
+
+        .INPUTS
+        None. You cannot pipe objects.
+
+        .OUTPUTS
+        No explicit output.
+
+        .EXAMPLE
+        PS> ci-cargo --version
+            ::group::
+            Running cargo --version
+            cargo 1.49.0 (d00d64df9 2020-12-05)
+            ::endgroup::
+
+        .EXAMPLE
+        PS> ci-cargo -ActioName "Build"  build
+
+        .EXAMPLE
+        PS> ci-cargo +stable-x86_64-pc-windows-gnu test --features tests-all --target i686-pc-windows-gnu '--' --nocapture -ActionName "Called from documentation"
+
+        .LINK
+        Used by: https://github.com/extendr/extendr
+    #>
+    
+}


### PR DESCRIPTION
In light of the new release of Rtools (Rtools40v2, see discussion here https://github.com/extendr/libR-sys/issues/21), which allows us to finally fix Rtools bindgen tests, I suggest to slightly improve the CI, reducing the amount of boilerplate.
This was previously done in `extendr` by introducing `ci-cargo.ps1` powershell script that handles `cargo` errors in a cross-platform manner. 

I took [`ci-cargo.ps1`](https://github.com/extendr/extendr/blob/master/ci-cargo.ps1) from `extendr` and replaced all boilerplate code with simple calls to `ci-cargo`.

