### PR TITLE
Fix macos-11 runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
           - {os: macOS-latest,   r: 'devel',   rust-version: 'stable'}
           - {os: macOS-latest,   r: 'oldrel',  rust-version: 'stable'}
-          - {os: macOS-11.0,     r: 'release', rust-version: 'nightly',      targets: ['default', 'aarch64-apple-darwin'], 
+          - {os: macOS-11,       r: 'release', rust-version: 'nightly',      targets: ['default', 'aarch64-apple-darwin'], 
             no-test-targets: 'aarch64-apple-darwin', emit-bindings: 'true'}
 
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}


### PR DESCRIPTION
The document says:

> macOS 11 image label was changed to macos-11 to avoid confusion with the minor version.
<https://github.com/actions/virtual-environments/blob/main/docs/macos-11-onboarding.md>

but, reading the above documentation, maybe this isn't available to us until we apply for the feature? Let's see what will happen...