### PR TITLE
Setup a CI to push generated bindings to a dedicated branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,7 +300,6 @@ jobs:
 
         # detect changes (the code is derived from https://stackoverflow.com/a/3879077)
         git add bindings/
-
         git update-index --refresh
         if ! git diff-index --quiet HEAD -- bindings/; then
           git config --local user.name "${GITHUB_ACTOR}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
   # Run this once per three days
   schedule:
     - cron: '29 17 */3 * *'
+  # This can also manually run
+  workflow_dispatch: {}
 
 jobs:
 
@@ -318,3 +320,5 @@ jobs:
         else
           echo "No changes"
         fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,8 +285,17 @@ jobs:
 
     - uses: actions/download-artifact@v2
         
-    - name: Display structure of downloaded files
+    - name: Push the generated bindings
       run: |
+        # 1) If there's already generated_bindings branch, checkout it.
+        # 2) If generated_binding branch is not created, create it from the default branch.
+        if git ls-remote --exit-code --heads upstream generated_bindings 2>&1 >/dev/null; then
+          git fetch origin --no-tags --prune --depth=1 generated_bindings
+          git checkout generated_bindings
+        else
+          git switch -c generated_bindings
+        fi
+
         # Update or add the bindings
         cp generated_binding-*/*.rs bindings/
 
@@ -305,7 +314,7 @@ jobs:
           git config --local user.name "${GITHUB_ACTOR}"
           git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git commit -m "Update bindings [skip ci]"
-          git push origin "${GITHUB_REF}":generated_bindings
+          git push origin generated_bindings
         else
           echo "No changes"
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,6 +317,21 @@ jobs:
           git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git commit -m "Update bindings [skip ci]"
           git push origin generated_bindings
+
+          # File an issue or a pull request
+          echo "Update the precomputed bindings"                          >  .msg
+          echo ""                                                         >> .msg
+          echo "The generated bindings have changed for these platforms:" >> .msg
+          echo ""                                                         >> .msg
+          git diff --name-only HEAD^ | sed 's/^/- /'                      >> .msg
+          echo ""                                                         >> .msg
+          echo "Please check the diff at <https://github.com/extendr/libR-sys/compare/master...generated_bindings?expand=1>" >> .msg
+
+          if ! (hub issue | grep -q "Update the precomputed bindings"); then
+            hub issue create -F .msg
+
+            hub pull-request --base master -m "Update the precomputed bindings"
+          fi
         else
           echo "No changes"
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,5 +310,3 @@ jobs:
         else
           echo "No changes"
         fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
       - master
+  # Run this once per three days
+  schedule:
+    - cron: '29 17 */3 * *'
 
 jobs:
 
@@ -171,7 +174,7 @@ jobs:
             (matrix.config.emit-bindings == 'true'))
         uses: actions/upload-artifact@main
         with:
-          name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }}) generated bindings
+          name: generated_binding-${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}
           path: generated_bindings
 
       # Run tests again using different bindings
@@ -269,5 +272,43 @@ jobs:
           }
         env: 
           NO_TEST_TARGETS: ${{ join(matrix.config.no-test-targets, ',') }}
+  
+  # Gather the generated bindings and push them to generated_bindings branch.
+  # If we need to update the bindings, create a pull request from that branch.
+  commit_generated_bindings:
+    needs: test_with_bindgen
+    runs-on: ubuntu-latest
+    # Do not run this on pull request
+    if: github.ref == 'refs/heads/master'
+    steps:
+    - uses: actions/checkout@v2
 
-      
+    - uses: actions/download-artifact@v2
+        
+    - name: Display structure of downloaded files
+      run: |
+        # Update or add the bindings
+        cp generated_binding-*/*.rs bindings/
+
+        # Replace the default bindings
+        cd bindings
+        for x in linux-x86_64 macos-aarch64 macos-x86_64 windows-x86 windows-x86_64; do
+          # Choose the newest version except for devel
+          ln --force -s "$(ls -1 ./bindings-${x}-*.rs | grep -v devel | sort | tail -1)" ./bindings-${x}.rs
+        done
+        cd ..
+
+        # detect changes (the code is derived from https://stackoverflow.com/a/3879077)
+        git add bindings/
+
+        git update-index --refresh
+        if ! git diff-index --quiet HEAD -- bindings/; then
+          git config --local user.name "${GITHUB_ACTOR}"
+          git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git commit -m "Update bindings [skip ci]"
+          git push origin "${GITHUB_REF}":generated_bindings
+        else
+          echo "No changes"
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -291,7 +291,7 @@ jobs:
       run: |
         # 1) If there's already generated_bindings branch, checkout it.
         # 2) If generated_binding branch is not created, create it from the default branch.
-        if git ls-remote --exit-code --heads upstream generated_bindings 2>&1 >/dev/null; then
+        if git ls-remote --exit-code --heads origin generated_bindings 2>&1 >/dev/null; then
           git fetch origin --no-tags --prune --depth=1 generated_bindings
           git checkout generated_bindings
         else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,23 +317,6 @@ jobs:
           git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git commit -m "Update bindings [skip ci]"
           git push origin generated_bindings
-
-          # File an issue or a pull request
-          echo "Update the precomputed bindings"                          >  .msg
-          echo ""                                                         >> .msg
-          echo "The generated bindings have changed for these platforms:" >> .msg
-          echo ""                                                         >> .msg
-          git diff --name-only HEAD^ | sed 's/^/- /'                      >> .msg
-          echo ""                                                         >> .msg
-          echo "Please check the diff at <https://github.com/extendr/libR-sys/compare/master...generated_bindings?expand=1>" >> .msg
-
-          if ! (hub issue | grep -q "Update the precomputed bindings"); then
-            hub issue create -F .msg
-
-            hub pull-request --base master -m "Update the precomputed bindings"
-          fi
         else
           echo "No changes"
         fi
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/MAINTAINERS_GUIDE.md
+++ b/MAINTAINERS_GUIDE.md
@@ -1,0 +1,16 @@
+## Precomputed bindings
+
+### How to update the precomputed bindings?
+
+The precomputed bindings are continuously updated on `generated_bindings` branch,
+but it doesn't propagate into `master` branch automatically; when we need to
+reflect the recent changes, create a pull request from `generated_bindings` branch.
+This link is the shortcut for this:
+
+<https://github.com/extendr/libR-sys/compare/master...generated_bindings?expand=1>
+
+### How to address conflicts in `generated_bindings`?
+
+You can just delete the branch. Since the GitHub Actions CI runs periodically,
+it will be created again from the latest `master` in a few days (or you can
+retrigger the build manually).


### PR DESCRIPTION
Related to #57

This pull request adds a job to gather the uploaded generated bindings and commit them to `generated_bindings` branch. We can create a pull request from that branch at any point we want to update the bindings. Of course we can commit this to the master branch, but I feel this should be done manually with checking the diffs by our eyes, at least at the moment.

This does nothing if there's no diffs, and even if something goes wrong, this pushes to non-`master`, where no CI is set up. So, I believe this should be safe.

This pull request adds a scheduled run setting. I use this on https://github.com/ggplot2-exts/gallery for a while and it works fine.

@Ilia-Kosenkov @clauswilke 
Please let me know if there's any concern, or any topic to discuss.