### PR TITLE
Use stable Rust to build and test aarch64-apple-darwin 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # options:
+          #   - targets: Targets to build and run tests against. If not specified, 'default' will be used. 
+          #   - no-test-targets: Targets to skip tests.
+          #   - emit-bindings: If 'true', emit binding no matter which Rust version is used (by default, the bindings are emitted only with stable Rust).
           - {os: windows-latest, r: 'release', rust-version: 'stable-msvc',  targets: ['x86_64-pc-windows-gnu', 'i686-pc-windows-gnu']}
           - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc', targets: ['x86_64-pc-windows-gnu', 'i686-pc-windows-gnu']}
           - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  targets: ['x86_64-pc-windows-gnu', 'i686-pc-windows-gnu']}
@@ -35,8 +39,7 @@ jobs:
           - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
           - {os: macOS-latest,   r: 'devel',   rust-version: 'stable'}
           - {os: macOS-latest,   r: 'oldrel',  rust-version: 'stable'}
-          - {os: macOS-11,       r: 'release', rust-version: 'stable',      targets: ['default', 'aarch64-apple-darwin'], 
-            no-test-targets: 'aarch64-apple-darwin', emit-bindings: 'true'}
+          - {os: macOS-11,       r: 'release', rust-version: 'stable',       targets: ['aarch64-apple-darwin']}
 
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,9 +301,6 @@ jobs:
           git switch -c generated_bindings
         fi
 
-        # TODO: workaround for https://github.com/extendr/libR-sys/pull/60#issuecomment-864483474
-        rm generated_binding-macOS-11-R-release-rust-nightly/bindings-macos-x86_64-*.rs
-
         # Update or add the bindings
         cp generated_binding-*/*.rs bindings/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,8 @@ jobs:
           - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
           - {os: macOS-latest,   r: 'devel',   rust-version: 'stable'}
           - {os: macOS-latest,   r: 'oldrel',  rust-version: 'stable'}
-          - {os: macOS-11,       r: 'release', rust-version: 'stable',       targets: ['aarch64-apple-darwin']}
+          # TODO: Remove no-test-targets when aarch64 runner is available
+          - {os: macOS-11,       r: 'release', rust-version: 'stable', targets: ['default', 'aarch64-apple-darwin'], no-test-targets: 'aarch64-apple-darwin'}
 
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'nightly', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
@@ -300,6 +301,9 @@ jobs:
         else
           git switch -c generated_bindings
         fi
+
+        # TODO: workaround for https://github.com/extendr/libR-sys/pull/60#issuecomment-864483474
+        rm generated_binding-macOS-11-R-release-rust-nightly/bindings-macos-x86_64-*.rs
 
         # Update or add the bindings
         cp generated_binding-*/*.rs bindings/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           - {os: macOS-latest,   r: 'release', rust-version: 'nightly'}
           - {os: macOS-latest,   r: 'devel',   rust-version: 'stable'}
           - {os: macOS-latest,   r: 'oldrel',  rust-version: 'stable'}
-          - {os: macOS-11,       r: 'release', rust-version: 'nightly',      targets: ['default', 'aarch64-apple-darwin'], 
+          - {os: macOS-11,       r: 'release', rust-version: 'stable',      targets: ['default', 'aarch64-apple-darwin'], 
             no-test-targets: 'aarch64-apple-darwin', emit-bindings: 'true'}
 
           - {os: ubuntu-20.04,   r: 'release', rust-version: 'stable',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}


### PR DESCRIPTION
At the time of we added `macos-11` runner, the nightly toolchain was needed. But, as of [Rust 1.49](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html), `aarch64-apple-darwin` is tier 2 target. This pull request adds the following changes regarding to this issue:

- Use stable toolchain
- ~~Remove default target~~
- ~~Remove an workaround for duplication of the generated bindings~~