### PR TITLE
Fix workaround on binding generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -303,7 +303,7 @@ jobs:
         fi
 
         # TODO: workaround for https://github.com/extendr/libR-sys/pull/60#issuecomment-864483474
-        rm generated_binding-macOS-11-R-release-rust-nightly/bindings-macos-x86_64-*.rs
+        rm generated_binding-macOS-11-R-release-rust-stable/bindings-macos-x86_64-*.rs
 
         # Update or add the bindings
         cp generated_binding-*/*.rs bindings/


### PR DESCRIPTION
Fix this error.

```
rm: cannot remove 'generated_binding-macOS-11-R-release-rust-nightly/bindings-macos-x86_64-*.rs': No such file or directory
```
https://github.com/extendr/libR-sys/runs/2984489270?check_suite_focus=true#step:4:42