### PR TITLE
Fix broken crates.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Low-level R library bindings
 
 [![Github Actions Build Status](https://github.com/extendr/libR-sys/workflows/Tests/badge.svg)](https://github.com/extendr/libR-sys/actions)
-[![crates.io](http://meritbadge.herokuapp.com/libR-sys)](https://crates.io/crates/libR-sys)
+[![crates.io](https://img.shields.io/crates/v/libR-sys.svg)](https://crates.io/crates/libR-sys)
 [![Documentation](https://docs.rs/libR-sys/badge.svg)](https://docs.rs/libR-sys)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
The same fix as https://github.com/extendr/extendr/pull/245