### PR TITLE
Move documents about DEP_* envvars to crate level

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,33 +211,3 @@ The output folder for bindings can be configured using `LIBRSYS_BINDINGS_OUTPUT_
   ```
   </details>
 
-## Conditional compilation depending on R installation
-
-libR-sys crate provides these environmental variables that you can use in `build.rs`:
-
-- `DEP_R_R_VERSION_MAJOR`: The major part of the R version (e.g. `4` in version `4.1.0`)
-- `DEP_R_R_VERSION_MINOR`: The minor part of the R version (e.g. `1` in version `4.1.0`)
-- `DEP_R_R_VERSION_PATCH`: The patch part of the R version (e.g. `0` in version `4.1.0`)
-- `DEP_R_R_VERSION_DEVEL`: `true` if the R is a development version, otherwise `false`
-- `DEP_R_R_VERSION_STRING`: The full version string (e.g. `R version 4.1.0 (2021-05-18)`)
-- `DEP_R_R_HOME`: The R home directory
-
-### Example `build.rs`
-
-``` rust
-use std::env;
-
-fn main() {
-    // Set R_HOME envvar, and refer to it on compile time by env!("R_HOME")
-    let r_home = env::var("DEP_R_R_HOME").unwrap();
-    println!("cargo:rustc-env=R_HOME={}", r_home);
-
-    // Enable cfg setting to conditionally compile a code using a feature
-    // available only on newer versions of R
-    let major = env::var("DEP_R_R_VERSION_MAJOR").unwrap();
-    let minor = env::var("DEP_R_R_VERSION_MINOR").unwrap();
-    if &*major >= "4" && &*minor >= "1" {
-        println!("cargo:rustc-cfg=use_a_feature");
-    }
-}
-```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! # Conditional compilation depending on R installation
 //!
-//! libR-sys crate provides these environmental variables that you can use in `build.rs`:
+//! The libR-sys crate provides these environmental variables that you can use in `build.rs`:
 //!
 //! - `DEP_R_R_VERSION_MAJOR`: The major part of the R version (e.g. `4` in version `4.1.0`)
 //! - `DEP_R_R_VERSION_MINOR`: The minor part of the R version (e.g. `1` in version `4.1.0`)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! ## Example `build.rs`
 //!
-//! ``` rust
+//! ```ignore
 //! use std::env;
 //!
 //! fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,37 @@
 //!   setup_Rmainloop();
 //! }
 //! ```
+//!
+//! # Conditional compilation depending on R installation
+//!
+//! libR-sys crate provides these environmental variables that you can use in `build.rs`:
+//!
+//! - `DEP_R_R_VERSION_MAJOR`: The major part of the R version (e.g. `4` in version `4.1.0`)
+//! - `DEP_R_R_VERSION_MINOR`: The minor part of the R version (e.g. `1` in version `4.1.0`)
+//! - `DEP_R_R_VERSION_PATCH`: The patch part of the R version (e.g. `0` in version `4.1.0`)
+//! - `DEP_R_R_VERSION_DEVEL`: `true` if the R is a development version, otherwise `false`
+//! - `DEP_R_R_VERSION_STRING`: The full version string (e.g. `R version 4.1.0 (2021-05-18)`)
+//! - `DEP_R_R_HOME`: The R home directory
+//!
+//! ## Example `build.rs`
+//!
+//! ``` rust
+//! use std::env;
+//!
+//! fn main() {
+//!     // Set R_HOME envvar, and refer to it on compile time by env!("R_HOME")
+//!     let r_home = env::var("DEP_R_R_HOME").unwrap();
+//!     println!("cargo:rustc-env=R_HOME={}", r_home);
+//!
+//!     // Enable cfg setting to conditionally compile a code using a feature
+//!     // available only on newer versions of R
+//!     let major = env::var("DEP_R_R_VERSION_MAJOR").unwrap();
+//!     let minor = env::var("DEP_R_R_VERSION_MINOR").unwrap();
+//!     if &*major >= "4" && &*minor >= "1" {
+//!         println!("cargo:rustc-cfg=use_a_feature");
+//!     }
+//! }
+//! ```
 
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
@@ -74,7 +105,13 @@ mod tests {
             if cfg!(target_os = "windows") && cfg!(target_arch = "x86") {
                 Rf_initialize_R(
                     4,
-                    [cstr_mut!("R"), cstr_mut!("--arch=i386"), cstr_mut!("--slave"), cstr_mut!("--no-save")].as_mut_ptr(),
+                    [
+                        cstr_mut!("R"),
+                        cstr_mut!("--arch=i386"),
+                        cstr_mut!("--slave"),
+                        cstr_mut!("--no-save"),
+                    ]
+                    .as_mut_ptr(),
                 );
             } else {
                 Rf_initialize_R(


### PR DESCRIPTION
After looking at the published doc (https://docs.rs/libR-sys/0.2.2/libR_sys/), I feel these documents should be on the crate level doc, rather than the README on crates.io.