### PR TITLE
Move to r-actions v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Set up R
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
@@ -222,7 +222,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up R
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 


### PR DESCRIPTION
r-actions got v2 branch a month ago, and all the future improvement will be included there. So we should migrate to v2.