### PR TITLE
Using `R_VERSION` environement variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ The recommended way to build this library is to use precomputed bindings, which 
 
 Alternatively, the library can be built from source, in which case it invokes `bindgen` crate, which has extra platform-specific dependencies (including `msys2` for `Windows`).
 
+## Configuration
+`libR-sys` recognizes the following environment variables:
+ - `R_VERSION` If set, it is used to determine the version of R, for which bindings should be generated. `R_VERSION` should be set to one of the supported values, e.g. `4.1.0` or `4.2.0-devel` (the pattern is `major.minor.patch[-devel]`). Malformed `R_VERSION` results in compilation error. If `R_VERSION` is unset, `R` is invoked and its `R.version` is used.
 
 ## Using precomputed bindings (recommended)
 

--- a/build.rs
+++ b/build.rs
@@ -294,7 +294,7 @@ fn get_r_version_from_r(r_paths: &InstallationPaths) -> io::Result<RVersionInfo>
 fn get_r_version(r_version_env_var: &str, r_paths: &InstallationPaths) -> io::Result<RVersionInfo> {
     get_r_version_from_env(r_version_env_var)
     .ok_or(Error::new(ErrorKind::Other, "Cannot determine R version from environement variable"))
-    .or(get_r_version_from_r(r_paths))
+    .or_else(|_| get_r_version_from_r(r_paths))
 }
 
 #[cfg(feature = "use-bindgen")]


### PR DESCRIPTION
Following the discussion in #85, here I attempt to use `R_VERSION` env var to determine R version. 
I assume that `R_VERSION` will be set to something like `4.1.0`, `4.2.0-devel`, etc.

`R_VERSION` takes precedence over executing `R` to get its version to allow manual overriding through the environment variable.