### PR TITLE
Change R_VERSION to LIBR_SYS_R_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Alternatively, the library can be built from source, in which case it invokes `b
 
 ## Configuration
 `libR-sys` recognizes the following environment variables:
- - `R_VERSION` If set, it is used to determine the version of R, for which bindings should be generated. `R_VERSION` should be set to one of the supported values, e.g. `4.1.0` or `4.2.0-devel` (the pattern is `major.minor.patch[-devel]`). Malformed `R_VERSION` results in compilation error. If `R_VERSION` is unset, `R` is invoked and its `R.version` is used.
+ - `LIBR_SYS_R_VERSION` If set, it is used to determine the version of R, for which bindings should be generated. `LIBR_SYS_R_VERSION` should be set to one of the supported values, e.g. `4.1.0` or `4.2.0-devel` (the pattern is `major.minor.patch[-devel]`). Malformed `LIBR_SYS_R_VERSION` results in compilation error. If `LIBR_SYS_R_VERSION` is unset, `R` is invoked and its `R.version` is used.
 
 ## Using precomputed bindings (recommended)
 

--- a/build.rs
+++ b/build.rs
@@ -465,7 +465,7 @@ fn main() {
     println!("cargo:rerun-if-changed=wrapper.h");
 
     // extract version info from R and output for use by downstream crates
-    let version_info = get_r_version("R_VERSION", &r_paths).expect("Could not obtain R version");
+    let version_info = get_r_version("LIBR_SYS_R_VERSION", &r_paths).expect("Could not obtain R version");
     set_r_version_vars(&version_info);
 
 


### PR DESCRIPTION
Related to #88.

It seems `R_VERSION` is also the envvar that is used by R itself. We need to use more specific one.