### PR TITLE
Refactor build.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   there will be no 32-bit version of R as of R 4.2.0.  
   To be clear, libR-sys (and extendr) crate will keep supporting 32-bit on R <
   4.2 for a year or so.
+- libR-sys no longer sets `DEP_R_R_VERSION_STRING` environmental variable.
 
 ## libR-sys 0.2.2
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Alternatively, the library can be built from source, in which case it invokes `b
 
 ## Configuration
 `libR-sys` recognizes the following environment variables:
- - `LIBR_SYS_R_VERSION` If set, it is used to determine the version of R, for which bindings should be generated. `LIBR_SYS_R_VERSION` should be set to one of the supported values, e.g. `4.1.0` or `4.2.0-devel` (the pattern is `major.minor.patch[-devel]`). Malformed `LIBR_SYS_R_VERSION` results in compilation error. If `LIBR_SYS_R_VERSION` is unset, `R` is invoked and its `R.version` is used.
+ - `LIBRSYS_R_VERSION` If set, it is used to determine the version of R, for which bindings should be generated. `LIBRSYS_R_VERSION` should be set to one of the supported values, e.g. `4.1.0` or `4.2.0-devel` (the pattern is `major.minor.patch[-devel]`). Malformed `LIBRSYS_R_VERSION` results in compilation error. If `LIBRSYS_R_VERSION` is unset, `R` is invoked and its `R.version` is used.
 
 ## Using precomputed bindings (recommended)
 

--- a/build.rs
+++ b/build.rs
@@ -336,7 +336,7 @@ fn get_r_version(
         Ok(v) => Ok(v),
         // If the envvar is not present, then use the actual R binary to get the version.
         Err(EnvVarError::EnvVarNotPresent) => get_r_version_from_r(r_paths),
-        // In the case of any other error than the absense of envvar, stop with
+        // In the case of any error other than the absense of envvar, stop with
         // that error because it means the envvar is set and something is wrong.
         e @ Err(_) => e,
     }

--- a/build.rs
+++ b/build.rs
@@ -180,7 +180,7 @@ fn parse_r_version(
     r_version: String,
     version_string: Option<String>,
 ) -> Result<RVersionInfo, EnvVarError> {
-    // Split "<major>.<minor>.<patch>-devel" to "<major>.<minor>.<patch>" and "devel"
+    // First, split "<major>.<minor>.<patch>-devel" to "<major>.<minor>.<patch>" and "devel"
     let (r_version, devel) = match *r_version.split('-').collect::<Vec<&str>>().as_slice() {
         [r_version, devel] => (r_version, Some(devel)),
         [r_version] => (r_version, None),
@@ -188,18 +188,16 @@ fn parse_r_version(
         _ => return Err(EnvVarError::InvalidEnvVar("Invalid format")),
     };
 
-    // Split "<major>.<minor>.<patch>-devel" to "<major>", "<minor>", and "<patch>"
+    // Split "<major>.<minor>.<patch>" to "<major>", "<minor>", and "<patch>"
     let r_version_split = r_version
         .split('.')
         .map(|s| {
             // Good:
             //   - "4.1.2"
-            //   - "4.2.0-devel"
             //
             // Bad:
-            //   - "4.1.foo" (contains non-digit character)
+            //   - "4.1.foo" (some part contains any non-digit characters)
             //   - "4.1." (some part is missing)
-            //   - "4.1.0-deve" (the devel part is invalid)
             if !s.is_empty() && s.chars().all(|c| c.is_digit(10)) {
                 Some(s)
             } else {

--- a/build.rs
+++ b/build.rs
@@ -128,7 +128,7 @@ fn get_r_library(r_home: &Path) -> PathBuf {
     match (cfg!(windows), pkg_target_arch.as_str()) {
         // For Windows
         (true, "x86_64") => Path::new(r_home).join("bin").join("x64"),
-        (true, "i386") => Path::new(r_home).join("bin").join("i386"),
+        (true, "x86") => Path::new(r_home).join("bin").join("i386"),
         (true, _) => panic!("Unknown architecture"),
         // For Unix-alike
         (false, _) => Path::new(r_home).join("lib"),

--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,7 @@ const ENVVAR_R_HOME: &str = "R_HOME";
 // An R version (e.g., "4.1.2" or "4.2.0-devel"). When this is set, the actual R
 // binary is not executed. This might be useful in some cases of cross-compile.
 // c.f., https://github.com/extendr/libR-sys/issues/85
-const ENVVAR_R_VERSION: &str = "LIBR_SYS_R_VERSION";
+const ENVVAR_R_VERSION: &str = "LIBRSYS_R_VERSION";
 
 // A path to a dir containing pre-computed bindings (default: "bindings").
 const ENVVAR_BINDINGS_PATH: &str = "LIBRSYS_BINDINGS_PATH";

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,14 @@
 use std::{
     env,
-    ffi::OsString,
-    fs,
-    io,
-    io::{ Error, ErrorKind },
-    path::{ Path, PathBuf },
-    process::{ exit, Command },
+    ffi::{OsStr, OsString},
+    fs, io,
+    io::{Error, ErrorKind},
+    path::{Path, PathBuf},
+    process::{exit, Command},
 };
 
 #[cfg(target_family = "unix")]
-use std::{
-    os::unix::ffi::OsStrExt,
-    ffi::OsStr,
-};
+use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
 #[cfg(target_family = "windows")]
 use std::os::windows::ffi::OsStringExt;
@@ -39,7 +35,7 @@ enum EnvVarError {
     EnvVarNotPresent,
     InvalidEnvVar(&'static str),
     RInvocationError(io::Error),
-    InvalidROutput(&'static str)
+    InvalidROutput(&'static str),
 }
 
 // frustratingly, something like the following does not exist in an
@@ -59,9 +55,23 @@ fn wide_from_console_string(bytes: &[u8]) -> Vec<u16> {
     let mut len;
     unsafe {
         let cp = winapi::um::consoleapi::GetConsoleCP();
-        len = winapi::um::stringapiset::MultiByteToWideChar(cp, 0, bytes.as_ptr() as *const i8, bytes.len() as i32, std::ptr::null_mut(), 0);
+        len = winapi::um::stringapiset::MultiByteToWideChar(
+            cp,
+            0,
+            bytes.as_ptr() as *const i8,
+            bytes.len() as i32,
+            std::ptr::null_mut(),
+            0,
+        );
         wide = Vec::with_capacity(len as usize);
-        len = winapi::um::stringapiset::MultiByteToWideChar(cp, 0, bytes.as_ptr() as *const i8, bytes.len() as i32, wide.as_mut_ptr(), len);
+        len = winapi::um::stringapiset::MultiByteToWideChar(
+            cp,
+            0,
+            bytes.as_ptr() as *const i8,
+            bytes.len() as i32,
+            wide.as_mut_ptr(),
+            len,
+        );
         wide.set_len(len as usize);
     }
     wide
@@ -183,9 +193,9 @@ fn parse_r_version(
         .map(|s| {
             if s.chars().all(|c| c.is_digit(10)) {
                 Some(s)
-    } else {
+            } else {
                 None
-    }
+            }
         })
         .collect::<Vec<Option<&str>>>();
 
@@ -197,7 +207,7 @@ fn parse_r_version(
         // if all of the first three items exist, the format is valid
         [Some(major), Some(minor), Some(patch)] => {
             (major.to_string(), minor.to_string(), patch.to_string())
-    }
+        }
         // if the length is longer than 3, the format is invalid
         _ => return Err(EnvVarError::InvalidEnvVar("Invalid format")),
     };
@@ -208,7 +218,7 @@ fn parse_r_version(
             return Err(EnvVarError::InvalidEnvVar(
                 "Cannot find R development status",
             ))
-    }
+        }
         None => false,
     };
 
@@ -219,7 +229,7 @@ fn parse_r_version(
         devel,
         version_string,
     })
-    }
+}
 
 fn get_r_version_from_env(r_version_env_var: &str) -> Result<RVersionInfo, EnvVarError> {
     std::env::var(r_version_env_var)
@@ -322,18 +332,20 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
-    println!("Generating bindings for target: {}, os: {}, architecture: {}", target, target_os, target_arch);
+    println!(
+        "Generating bindings for target: {}, os: {}, architecture: {}",
+        target, target_os, target_arch
+    );
     // Point to the correct headers
     bindgen_builder = bindgen_builder.clang_args(&[
         format!("-I{}", r_paths.include.display()),
-        format!("--target={}", target)
+        format!("--target={}", target),
     ]);
 
     // allow injection of an alternative include path to libclang
     if let Some(alt_include) = env::var_os("LIBRSYS_LIBCLANG_INCLUDE_PATH") {
-        bindgen_builder = bindgen_builder.clang_arg(
-            format!("-I{}", PathBuf::from(alt_include).display()),
-        );
+        bindgen_builder =
+            bindgen_builder.clang_arg(format!("-I{}", PathBuf::from(alt_include).display()));
     }
 
     // Blacklist some types on i686
@@ -341,8 +353,7 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
     // https://github.com/rust-lang/rust/issues/54341
     // https://github.com/extendr/libR-sys/issues/39
     if target_os == "windows" && target_arch == "x86" {
-        bindgen_builder = 
-            bindgen_builder
+        bindgen_builder = bindgen_builder
             .blacklist_item("max_align_t")
             .blacklist_item("__mingw_ldbl_type_t");
     }
@@ -360,22 +371,21 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings to default output path!");
 
-
     // Also write the bindings to a folder specified by LIBRSYS_BINDINGS_OUTPUT_PATH, if defined
     if let Some(alt_target) = env::var_os("LIBRSYS_BINDINGS_OUTPUT_PATH") {
         let out_path = PathBuf::from(alt_target);
         // if folder doesn't exist, try to create it
         if !out_path.exists() {
-            fs::create_dir(&out_path)
-                .expect(&format!("Couldn't create output directory for bindings: {}", out_path.display()));
+            fs::create_dir(&out_path).expect(&format!(
+                "Couldn't create output directory for bindings: {}",
+                out_path.display()
+            ));
         }
 
-        let out_file = out_path.join(
-                format!(
-                    "bindings-{}-{}-R{}.{}{}.rs",
-                    target_os, target_arch, version_info.major, version_info.minor, version_info.devel
-                )
-            );
+        let out_file = out_path.join(format!(
+            "bindings-{}-{}-R{}.{}{}.rs",
+            target_os, target_arch, version_info.major, version_info.minor, version_info.devel
+        ));
 
         bindings
             .write_to_file(&out_file)
@@ -383,27 +393,20 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
     }
 }
 
-
 #[allow(dead_code)]
 /// Retrieve bindings from cache, if available. Errors out otherwise.
 fn retrieve_prebuild_bindings(version_info: &RVersionInfo) {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let bindings_path = PathBuf::from(
-        env::var_os("LIBRSYS_BINDINGS_PATH")
-        .unwrap_or(OsString::from("bindings"))
-    );
-    
+    let bindings_path =
+        PathBuf::from(env::var_os("LIBRSYS_BINDINGS_PATH").unwrap_or(OsString::from("bindings")));
+
     // we try a few different file names, from more specific to less specific
-    let bindings_file_full = PathBuf::from(
-        format!(
-            "bindings-{}-{}-R{}.{}{}.rs",
-            target_os, target_arch, version_info.major, version_info.minor, version_info.devel
-        )
-    );
-    let bindings_file_novers = PathBuf::from(
-        format!("bindings-{}-{}.rs", target_os, target_arch)
-    );
+    let bindings_file_full = PathBuf::from(format!(
+        "bindings-{}-{}-R{}.{}{}.rs",
+        target_os, target_arch, version_info.major, version_info.minor, version_info.devel
+    ));
+    let bindings_file_novers = PathBuf::from(format!("bindings-{}-{}.rs", target_os, target_arch));
 
     let mut from = bindings_path.join(bindings_file_full);
     if !from.exists() {
@@ -423,9 +426,9 @@ fn retrieve_prebuild_bindings(version_info: &RVersionInfo) {
 
     fs::copy(
         &from,
-        PathBuf::from(env::var_os("OUT_DIR").unwrap())
-            .join("bindings.rs")
-    ).expect("No precomputed bindings available!");
+        PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("bindings.rs"),
+    )
+    .expect("No precomputed bindings available!");
     println!("cargo:rerun-if-changed={}", from.display());
 }
 
@@ -442,7 +445,7 @@ fn main() {
 
     println!("cargo:rustc-env=R_HOME={}", r_paths.r_home.display());
     println!("cargo:r_home={}", r_paths.r_home.display()); // Becomes DEP_R_R_HOME for clients
-    // make sure cargo links properly against library
+                                                           // make sure cargo links properly against library
     println!("cargo:rustc-link-search={}", r_paths.library.display());
     println!("cargo:rustc-link-lib=dylib=R");
 
@@ -450,12 +453,12 @@ fn main() {
     println!("cargo:rerun-if-changed=wrapper.h");
 
     // extract version info from R and output for use by downstream crates
-    let version_info = get_r_version("LIBR_SYS_R_VERSION", &r_paths).expect("Could not obtain R version");
+    let version_info =
+        get_r_version("LIBR_SYS_R_VERSION", &r_paths).expect("Could not obtain R version");
     set_r_version_vars(&version_info);
 
-
     #[cfg(feature = "use-bindgen")]
-        generate_bindings(&r_paths, &version_info);
+    generate_bindings(&r_paths, &version_info);
     #[cfg(not(feature = "use-bindgen"))]
-        retrieve_prebuild_bindings(&version_info);
+    retrieve_prebuild_bindings(&version_info);
 }

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 #[cfg(target_family = "unix")]
-use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+use std::os::unix::ffi::OsStrExt;
 
 #[cfg(target_family = "windows")]
 use std::os::windows::ffi::OsStringExt;

--- a/build.rs
+++ b/build.rs
@@ -174,7 +174,7 @@ fn get_r_library(r_home: &Path) -> PathBuf {
     }
 }
 
-// Get the path to the R include either from an envvar or by executing the actual R binary.
+// Get the path to the R include directory either from an envvar or by executing the actual R binary.
 fn get_r_include(r_home: &Path, library: &Path) -> io::Result<PathBuf> {
     // If the environment variable R_INCLUDE_DIR is set we use it
     if let Some(include) = env::var_os(ENVVAR_R_INCLUDE_DIR) {

--- a/build.rs
+++ b/build.rs
@@ -339,11 +339,7 @@ fn set_r_version_vars(ver: &RVersionInfo) {
     println!("cargo:r_version_major={}", ver.major); // Becomes DEP_R_R_VERSION_MAJOR for clients
     println!("cargo:r_version_minor={}", ver.minor); // Becomes DEP_R_R_VERSION_MINOR for clients
     println!("cargo:r_version_patch={}", ver.patch); // Becomes DEP_R_R_VERSION_PATCH for clients
-    if ver.devel {
-        println!("cargo:r_version_devel=false"); // Becomes DEP_R_R_VERSION_DEVEL for clients
-    } else {
-        println!("cargo:r_version_devel=true");
-    }
+    println!("cargo:r_version_devel={}", ver.devel); // Becomes DEP_R_R_VERSION_DEVEL for clients
     if let Some(version_string) = ver.version_string.clone() {
         println!(r#"cargo:r_version_string="{}""#, version_string); // Becomes DEP_R_R_VERSION_STRING for clients
     }

--- a/build.rs
+++ b/build.rs
@@ -68,6 +68,16 @@ struct RVersionInfo {
     devel: bool,
 }
 
+impl RVersionInfo {
+    fn get_r_bindings_filename(&self, target_os: &str, target_arch: &str) -> PathBuf {
+        let devel_suffix = if self.devel { "-devel" } else { "" };
+        PathBuf::from(format!(
+            "bindings-{}-{}-R{}.{}{}.rs",
+            target_os, target_arch, self.major, self.minor, devel_suffix
+        ))
+    }
+}
+
 #[derive(Debug)]
 enum EnvVarError {
     EnvVarNotPresent,
@@ -409,10 +419,8 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
             ));
         }
 
-        let out_file = out_path.join(format!(
-            "bindings-{}-{}-R{}.{}{}.rs",
-            target_os, target_arch, version_info.major, version_info.minor, version_info.devel
-        ));
+        let bindings_file_full = version_info.get_r_bindings_filename(&target_os, &target_arch);
+        let out_file = out_path.join(bindings_file_full);
 
         bindings
             .write_to_file(&out_file)
@@ -430,10 +438,7 @@ fn retrieve_prebuild_bindings(version_info: &RVersionInfo) {
     );
 
     // we try a few different file names, from more specific to less specific
-    let bindings_file_full = PathBuf::from(format!(
-        "bindings-{}-{}-R{}.{}{}.rs",
-        target_os, target_arch, version_info.major, version_info.minor, version_info.devel
-    ));
+    let bindings_file_full = version_info.get_r_bindings_filename(&target_os, &target_arch);
     let bindings_file_novers = PathBuf::from(format!("bindings-{}-{}.rs", target_os, target_arch));
 
     let mut from = bindings_path.join(bindings_file_full);

--- a/build.rs
+++ b/build.rs
@@ -445,7 +445,8 @@ fn main() {
 
     println!("cargo:rustc-env=R_HOME={}", r_paths.r_home.display());
     println!("cargo:r_home={}", r_paths.r_home.display()); // Becomes DEP_R_R_HOME for clients
-                                                           // make sure cargo links properly against library
+
+    // make sure cargo links properly against library
     println!("cargo:rustc-link-search={}", r_paths.library.display());
     println!("cargo:rustc-link-lib=dylib=R");
 

--- a/build.rs
+++ b/build.rs
@@ -192,7 +192,15 @@ fn parse_r_version(
     let r_version_split = r_version
         .split('.')
         .map(|s| {
-            if s.chars().all(|c| c.is_digit(10)) {
+            // Good:
+            //   - "4.1.2"
+            //   - "4.2.0-devel"
+            //
+            // Bad:
+            //   - "4.1.foo" (contains non-digit character)
+            //   - "4.1." (some part is missing)
+            //   - "4.1.0-deve" (the devel part is invalid)
+            if !s.is_empty() && s.chars().all(|c| c.is_digit(10)) {
                 Some(s)
             } else {
                 None

--- a/build.rs
+++ b/build.rs
@@ -410,8 +410,9 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
 fn retrieve_prebuild_bindings(version_info: &RVersionInfo) {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let bindings_path =
-        PathBuf::from(env::var_os("LIBRSYS_BINDINGS_PATH").unwrap_or(OsString::from("bindings")));
+    let bindings_path = PathBuf::from(
+        env::var_os("LIBRSYS_BINDINGS_PATH").unwrap_or_else(|| OsString::from("bindings")),
+    );
 
     // we try a few different file names, from more specific to less specific
     let bindings_file_full = PathBuf::from(format!(

--- a/build.rs
+++ b/build.rs
@@ -175,6 +175,7 @@ fn probe_r_paths() -> io::Result<InstallationPaths> {
     })
 }
 
+// Parse an R version (e.g. "4.1.2" and "4.2.0-devel") and return the RVersionInfo.
 fn parse_r_version(
     r_version: String,
     version_string: Option<String>,
@@ -287,10 +288,15 @@ fn get_r_version(
     r_version_env_var: &str,
     r_paths: &InstallationPaths,
 ) -> Result<RVersionInfo, EnvVarError> {
+    // Try looking for the envvar first.
     match get_r_version_from_env(r_version_env_var) {
+        // If the envvar is found and it can be parsed as a valid RVersionInfo, use it.
         Ok(v) => Ok(v),
-        e @ Err(EnvVarError::InvalidEnvVar(_)) => e,
-        Err(_) => get_r_version_from_r(r_paths),
+        // If the envvar is not present, then use the actual R binary to get the version.
+        Err(EnvVarError::EnvVarNotPresent) => get_r_version_from_r(r_paths),
+        // In the case of any other error than the absense of envvar, stop with
+        // that error because it means the envvar is set and something is wrong.
+        e @ Err(_) => e,
     }
 }
 


### PR DESCRIPTION
We have added several new logics to build.rs with minimal changes. I feel now it looks fairly complex and needs to be refactored. The main changes of this pull request are the followings. The behavior of the script should stay (almost) the same.

* Currently we have two different code paths to parse the R version on envvar `LIBR_SYS_R_VERSION` and on R's output. This pull request unifies it to `parse_r_version()`.
* `probe_r_paths()` is a bit too nested. This pull request separates the logic into `get_r_home()`, `get_r_library()`, and `get_r_include()` for simplicity.
* Make the environmental variables in our convention as const and move to the top of the file so that we can discover it easier.
* Add more comments.