### PR TITLE
Remove a workaround for macOS runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -320,9 +320,6 @@ jobs:
           git switch -c generated_bindings
         fi
 
-        # TODO: workaround for https://github.com/extendr/libR-sys/pull/60#issuecomment-864483474
-        rm generated_binding-macOS-11-R-release-rust-stable/bindings-macos-x86_64-*.rs
-
         # Update or add the bindings
         cp generated_binding-*/*.rs bindings/
 


### PR DESCRIPTION
This workaround was needed because we had two macOS runners for stable Rust. But after #99 we don't need this workaround.

I'm merging this as this only affects the trick of updating `generated_bindings` branch and the usual tests are not changed.