### PR TITLE
Use the MSVC toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,24 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # On Windows,
+          #
+          # * for R >= 4.2, both the MSVC toolchain and the GNU toolchain should
+          #   work. Since our main support is on MSVC, we mainly test MSVC here.
+          #   Also, at least one GNU case should be included so that we can
+          #   detect when something gets broken. 
+          # * for R < 4.2, the MSVC toolchain must be used to support
+          #   cross-compilation for the 32-bit. 
+          # 
           # options:
           #   - targets: Targets to build and run tests against. If not specified, 'default' will be used. 
           #   - no-test-targets: Targets to skip tests.
-          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
-          - {os: windows-latest, r: 'release', rust-version: 'nightly-gnu', targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
-          # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
-          # Change this to the GNU toolchain as well when 'oldrel' points to R 4.2 or above.
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc',  targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'release', rust-version: 'nightly-msvc', targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc',  targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',   targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'release', rust-version: 'nightly-gnu',  targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',   targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
           - {os: windows-latest, r: 'oldrel',  rust-version: 'stable-msvc', targets: ['x86_64-pc-windows-gnu', 'i686-pc-windows-gnu']}
 
           #- {os: macOS-latest,   r: 'release', rust-version: 'stable'}
@@ -228,11 +238,19 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',   targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
-          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',   targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
-          # For R < 4.2, the MSVC toolchain is used to support cross-compilation for the 32-bit.
-          # TODO: Remove this runner when we drop the support for R < 4.2
-          - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc',  targets: ['x86_64-pc-windows-gnu', 'i686-pc-windows-gnu']}
+          # On Windows,
+          #
+          # * for R >= 4.2, both the MSVC toolchain and the GNU toolchain should
+          #   work. Since our main support is on MSVC, we mainly test MSVC here.
+          #   Also, at least one GNU case should be included so that we can
+          #   detect when something gets broken. 
+          # * for R < 4.2, the MSVC toolchain must be used to support
+          #   cross-compilation for the 32-bit. 
+          - {os: windows-latest, r: 'release', rust-version: 'stable-msvc', targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-msvc', targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'release', rust-version: 'stable-gnu',  targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: 'devel',   rust-version: 'stable-gnu',  targets: ['x86_64-pc-windows-gnu'], rtools-version: '42'}
+          - {os: windows-latest, r: '4.1',     rust-version: 'stable-msvc', targets: ['x86_64-pc-windows-gnu', 'i686-pc-windows-gnu']}
 
     env:
       RSPM: ${{ matrix.config.rspm }}
@@ -297,17 +315,15 @@ jobs:
           #  
           # If we use the Rtools' toolchain, the second tweak is also required.
           # `rustc` adds `-lgcc_eh` and `-lgcc_s` flags to the compiler, but
-          # Rtools' GCC doesn't have `libgcc_eh` or `libgcc_a` due to the 
+          # Rtools' GCC doesn't have `libgcc_eh` or `libgcc_s` due to the 
           # compilation settings. So, in order to please the compiler, we need
-          # to add empty `libgcc_eh` or `libgcc_a` to the library search paths.
+          # to add empty `libgcc_eh` or `libgcc_s` to the library search paths.
           # 
           # For more details, please refer to https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
 
           New-Item -Path libgcc_mock -Type Directory
-          New-Item -Path libgcc_mock\gcc.c -Type File
-          x86_64-w64-mingw32.static.posix-gcc.exe -c libgcc_mock\gcc.c -o libgcc_mock\gcc.o
-          x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_eh.a libgcc_mock\gcc.o
-          x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_s.a libgcc_mock\gcc.o
+          New-Item -Path libgcc_mock\libgcc_eh.a -Type File
+          New-Item -Path libgcc_mock\libgcc_s.a -Type File
 
           New-Item -Path .cargo -ItemType Directory -Force
           $pwd_slash = echo "${PWD}" | % {$_ -replace '\\','/'}

--- a/README-old-windows.md
+++ b/README-old-windows.md
@@ -1,0 +1,161 @@
+# Windows (R < 4.2) 
+
+## Using precompiled bindings (recommended)
+
+Two components are required to build the library:
+1. [R](https://cran.r-project.org/): It needs to be installed and available in the search path.
+2. [rust](https://www.rust-lang.org/learn/get-started): It is recommended to install `rust` using `rustup`; search path should include `rust` binaries.
+
+Once `R` and `rust` are configured, the library can be easily built:
+  
+On Windows, the toolchain setup is a bit complex. Please refer to the "Toolchain setup on Windows" section below.
+```Shell
+cargo +stable-msvc build --target x86_64-pc-windows-gnu # 64-bit
+cargo +stable-msvc build --target   i686-pc-windows-gnu # 32-bit
+```
+
+To test the build, run `cargo test`.
+
+On Windows, the toolchain setup is a bit complex. Please refer to the "Toolchain setup on Windows" section below.
+
+For 64-bit R,
+```pwsh
+cargo +stable-msvc test --target x86_64-pc-windows-gnu
+```
+For 32-bit R,
+```pwsh
+cargo +stable-msvc test --target i686-pc-windows-gnu
+```
+
+## Building bindings from source (advanced)
+
+The bindings can be generated using [bindgen](https://github.com/rust-lang/rust-bindgen), special `rust` crate. 
+`bindgen` usage is enabled via `use-bindgen` feature flag.
+
+`bindgen` requires [libclang](https://clang.llvm.org/docs/Tooling.html), which should be installed first. 
+This library relies on `LIBCLANG_PATH` environment variable to determine path to the appropriate version of `libclang`.
+
+The output folder for bindings can be configured using `LIBRSYS_BINDINGS_OUTPUT_PATH` environment variable.
+
+Binding generation on Windows happens with the help of `MSYS2`.
+Make sure the environment variable `MSYS_ROOT` points to `MSYS2` root, e.g., `C:\tools\msys64`.
+
+<details>
+<summary>Installing and configuring MSYS2</summary>
+
+Install `MSYS2`. Here is an example using  `chocolatey`:
+```Shell
+choco install msys2 -y
+```
+Set up `MSYS_ROOT` environment variable.
+Install `clang` and `mingw`-toolchains (assuming `PowerShell` syntax)
+
+```pwsh
+&"$env:MSYS_ROOT\usr\bin\bash" -l -c "pacman -S --noconfirm mingw-w64-x86_64-clang mingw-w64-x86_64-toolchain"      # 64-bit
+&"$env:MSYS_ROOT\usr\bin\bash" -l -c "pacman -S --noconfirm mingw32/mingw-w64-i686-clang mingw-w64-i686-toolchain"  # 32-bit
+```
+
+</details>
+
+For 64-bit R, add the following to the `PATH` (using `PowerShell` syntax):
+```pwsh
+$env:PATH += ";$env:R_HOME\bin\x64;$env:MSYS_ROOT\mingw64\bin"
+```
+then build & test with 
+```pwsh
+cargo +stable-msvc build --target x86_64-pc-windows-gnu --features use-bindgen
+cargo +stable-msvc  test --target x86_64-pc-windows-gnu --features use-bindgen
+```
+
+For 32-bit R, 
+```pwsh
+$env:PATH += ";$env:R_HOME\bin\i386;$env:MSYS_ROOT\mingw64\bin$env:MSYS_ROOT\mingw32\bin"
+```
+and then build & test with 
+```pwsh
+cargo +stable-msvc build --target i686-pc-windows-gnu --features use-bindgen
+cargo +stable-msvc  test --target i686-pc-windows-gnu --features use-bindgen
+```
+
+<details>
+<summary>Generating x86 bindings using 32-bit process (optional)</summary>
+
+Add 32-bit `Rust` toolchain and configure target:
+
+```pwsh
+rustup toolchain install stable-i686-pc-windows-msvc
+rustup target add i686-pc-windows-gnu --toolchain stable-i686-pc-windows-msvc
+```
+Configure environment variables:
+```pwsh
+$env:PATH += ";$env:R_HOME\bin\i386;$env:MSYS_ROOT\mingw32\bin"
+```
+
+Build & test using specific toolchain
+```pwsh
+cargo +stable-i686-pc-windows-msvc build --target i686-pc-windows-gnu --features use-bindgen
+cargo +stable-i686-pc-windows-msvc  test --target i686-pc-windows-gnu --features use-bindgen
+```
+</details>
+
+## Toolchain setup on Windows
+
+### Install the `msvc` toolchain of Rust
+
+When building for `Windows` with older versions of R, the `msvc` toolchain and
+special `rust` targets should be added for compatibility with `R`:
+```Shell
+rustup toolchain install stable-msvc
+rustup target add x86_64-pc-windows-gnu  # 64-bit
+rustup target add   i686-pc-windows-gnu  # 32-bit
+```
+
+### Install Rtools40v2
+
+Rtools40 can be downloaded from [here][rtools40]. Alternatively, `Rtools` can be
+installed using `chocolatey`
+
+[rtools40]: https://cran.r-project.org/bin/windows/Rtools/rtools40.html
+
+```Shell
+choco install rtools --version=4.0.0.20220206 -y
+```
+
+Verify that the environment variable `RTOOLS40_HOME` is set up to point to the
+`Rtools` root.
+
+### Setup `R_HOME` and  `PATH` envvars
+
+First, ensure that `R_HOME` points to `R` home, e.g. `C:\Program Files\R\R-4.1.0`
+(in an R session, this should be set by R).
+
+Second, ensure that `PATH` is properly configured that the following executables
+are available:
+
+* the `R` binary to build against
+* the compiler toolchain that is used for compiling the R itself, i.e., `Rtools`
+
+Typically, they can be found in the following locations (using `PowerShell` syntax):
+
+|         | R                         | Rtools                             |
+| ------- | ------------------------- | ---------------------------------- |
+| 64-bit  |  `$env:R_HOME\bin\x64`   | `$env:RTOOLS40_HOME\mingw64\bin` |
+| 32-bit  |  `$env:R_HOME\bin\i386`  | `$env:RTOOLS40_HOME\mingw32\bin` |
+
+
+Typically, the following paths need to be added to the head of `PATH` (using
+`PowerShell` syntax) for 64-bit R.
+
+```pwsh
+$env:PATH = "${env:R_HOME}\bin\x64;${env:RTOOLS40_HOME}\mingw64\bin;${env:PATH}"
+```
+
+and for 32-bit R.
+
+```pwsh
+$env:PATH = "${env:R_HOME}\bin\i386;${env:RTOOLS40_HOME}\mingw32\bin;${env:PATH}"
+```
+
+Note that the above prepends, rather than appends, because otherwise the wrong
+toolchain might be accidentally chosen if the `PATH` already contains another
+version of `R` or compiler toolchain.

--- a/README.md
+++ b/README.md
@@ -20,70 +20,36 @@ Alternatively, the library can be built from source, in which case it invokes `b
 ## Using precompiled bindings (recommended)
 
 Two components are required to build the library:
-1. [R](https://cran.r-project.org/): It needs to be installed and available in the search path.
-2. [rust](https://www.rust-lang.org/learn/get-started): It is recommended to install `rust` using `rustup`; search path should include `rust` binaries.
+1. [`R`](https://cran.r-project.org/): It needs to be installed and available in the search path.
+2. [`Rust`](https://www.rust-lang.org/learn/get-started): It is recommended to install `Rust` using `rustup`; search path should include `Rust` binaries.
 
-Once `R` and `rust` are configured, the library can be easily built:
-- **macOS/Linux**
-  ```Shell
-  cargo build
-  ```
+**Note: Windows with R < 4.2 requires more complex setup in order to support the 32-bit version. Please refer to [README-old-windows.md](./README-old-windows.md) for more details.**
 
-- **Windows (R >= 4.2)**
-  
-  On Windows, the toolchain setup is a bit complex. Please refer to the "Toolchain setup on Windows" section below.
-  ```Shell
-  cargo +stable-gnu build
-  ```
+Once `R` and `Rust` are configured, the library can be easily built:
 
-- **Windows (R < 4.2)**
-  
-  <details>
-  On Windows, the toolchain setup is a bit complex. Please refer to the "Toolchain setup on Windows" section below.
-  ```Shell
-  cargo +stable-msvc build --target x86_64-pc-windows-gnu # 64-bit
-  cargo +stable-msvc build --target   i686-pc-windows-gnu # 32-bit
-  ```
-  </details>
- 
+```bash
+# macOS & Linux
+cargo build
 
-
-
-
+# Windows
+cargo build --target x86_64-pc-windows-gnu
+```
 
 To test the build, run `cargo test`.
 
+```bash
+# macOS & Linux
+cargo test
 
-- **macOS/Linux**
-  ```bash
-  cargo test
-  ```
-
-- **Windows (R >= 4.2)**
-  
-  On Windows, the toolchain setup is a bit complex. Please refer to the "Toolchain setup on Windows" section below.
-  ```pwsh
-  cargo +stable-gnu test
-  ```
-
-- **Windows (R < 4.2)**
-  
-  <details>
-  On Windows, the toolchain setup is a bit complex. Please refer to the "Toolchain setup on Windows" section below.
-
-  For 64-bit R,
-  ```pwsh
-  cargo +stable-msvc test --target x86_64-pc-windows-gnu
-  ```
-  For 32-bit R,
-  ```pwsh
-  cargo +stable-msvc test --target i686-pc-windows-gnu
-  ```
-  </details>
+# Windows
+cargo test --target x86_64-pc-windows-gnu
+```
 
 ## Building bindings from source (advanced)
 
-The bindings can be generated using [bindgen](https://github.com/rust-lang/rust-bindgen), special `rust` crate. 
+**Note: Windows with R < 4.2 requires more complex setup in order to support the 32-bit version. Please refer to [README-old-windows.md](./README-old-windows.md) for more details.**
+
+The bindings can be generated using [bindgen](https://github.com/rust-lang/rust-bindgen), special `Rust` crate. 
 `bindgen` usage is enabled via `use-bindgen` feature flag.
 
 `bindgen` requires [libclang](https://clang.llvm.org/docs/Tooling.html), which should be installed first. 
@@ -125,14 +91,15 @@ The output folder for bindings can be configured using `LIBRSYS_BINDINGS_OUTPUT_
   cargo build --features use-bindgen
   cargo test  --features use-bindgen 
   ```
-- **Windows (R >= 4.2)**
+
+- **Windows**
   Binding generation on Windows happens with the help of `MSYS2`.
   Make sure the environment variable `MSYS_ROOT` points to `MSYS2` root, e.g., `C:\tools\msys64`.
 
   <details>
     <summary>Installing and configuring MSYS2</summary>
 
-    Install `MSYS2`. Here is an example using  `chocolatey`:
+    Install `MSYS2`. Here is an example using `chocolatey`:
     ```Shell
     choco install msys2 -y
     ```
@@ -151,88 +118,27 @@ The output folder for bindings can be configured using `LIBRSYS_BINDINGS_OUTPUT_
   ```
   then build & test with 
   ```pwsh
-  cargo +stable-gnu build --features use-bindgen
+  cargo build --target x86_64-pc-windows-gnu --features use-bindgen
   ```
-  
-- **Windows (R < 4.2)**
-  <details>
-  Binding generation on Windows happens with the help of `MSYS2`.
-  Make sure the environment variable `MSYS_ROOT` points to `MSYS2` root, e.g., `C:\tools\msys64`.
-
-  <details>
-    <summary>Installing and configuring MSYS2</summary>
-
-    Install `MSYS2`. Here is an example using  `chocolatey`:
-    ```Shell
-    choco install msys2 -y
-    ```
-    Set up `MSYS_ROOT` environment variable.
-    Install `clang` and `mingw`-toolchains (assuming `PowerShell` syntax)
-
-    ```pwsh
-    &"$env:MSYS_ROOT\usr\bin\bash" -l -c "pacman -S --noconfirm mingw-w64-x86_64-clang mingw-w64-x86_64-toolchain"      # 64-bit
-    &"$env:MSYS_ROOT\usr\bin\bash" -l -c "pacman -S --noconfirm mingw32/mingw-w64-i686-clang mingw-w64-i686-toolchain"  # 32-bit
-    ```
-    
-  </details>
-
-  For 64-bit R, add the following to the `PATH` (using `PowerShell` syntax):
-  ```pwsh
-  $env:PATH += ";$env:R_HOME\bin\x64;$env:MSYS_ROOT\mingw64\bin"
-  ```
-  then build & test with 
-  ```pwsh
-  cargo +stable-msvc build --target x86_64-pc-windows-gnu --features use-bindgen
-  cargo +stable-msvc  test --target x86_64-pc-windows-gnu --features use-bindgen
-  ```
-
-  For 32-bit R, 
-  ```pwsh
-  $env:PATH += ";$env:R_HOME\bin\i386;$env:MSYS_ROOT\mingw64\bin$env:MSYS_ROOT\mingw32\bin"
-  ```
-  and then build & test with 
-  ```pwsh
-  cargo +stable-msvc build --target i686-pc-windows-gnu --features use-bindgen
-  cargo +stable-msvc  test --target i686-pc-windows-gnu --features use-bindgen
-  ```
-
-  <details>
-  <summary>Generating x86 bindings using 32-bit process (optional)</summary>
-
-  Add 32-bit `Rust` toolchain and configure target:
-
-  ```pwsh
-  rustup toolchain install stable-i686-pc-windows-msvc
-  rustup target add i686-pc-windows-gnu --toolchain stable-i686-pc-windows-msvc
-  ```
-  Configure environment variables:
-  ```pwsh
-  $env:PATH += ";$env:R_HOME\bin\i386;$env:MSYS_ROOT\mingw32\bin"
-  ```
-
-  Build & test using specific toolchain
-  ```pwsh
-  cargo +stable-i686-pc-windows-msvc build --target i686-pc-windows-gnu --features use-bindgen
-  cargo +stable-i686-pc-windows-msvc  test --target i686-pc-windows-gnu --features use-bindgen
-  ```
-  </details>
-  </details>
 
 ## Toolchain setup on Windows
 
-### Windows (R >= 4.2)
-
-When building for Windows with R >= 4.2, the GNU toolchain is required. The
-setup is tricky because the Rtools' toolchain is a bit different from the
+The setup is tricky because the Rtools' toolchain is a bit different from the
 assumption of Rust.
 
-#### Install the `gnu` toolchain of Rust
+### Install the GNU target of Rust
+
+Both the default MSVC toolchain and the GNU toolchain should work fine with
+libR-sys, but we recommend the MSVC toolchain because we mainly use it.
+
+With either toolchain, since the R itself is built with the GNU toolchain, the
+target must be GNU. So, the GNU target needs to be installed.
 
 ```Shell
-rustup toolchain install stable-gnu
+rustup target add x86_64-pc-windows-gnu
 ```
 
-#### Install Rtools42
+### Install Rtools42
 
 Rtools42 can be downloaded from [here][rtools_website]. Alternatively, `Rtools`
 will eventually be available on `chocolatey`.
@@ -244,7 +150,7 @@ will eventually be available on `chocolatey`.
 # choco install rtools -y
 ```
 
-#### Setup `R_HOME` and  `PATH` envvars
+### Setup `R_HOME` and  `PATH` envvars
 
 First, ensure that `R_HOME` points to `R` home, e.g. `C:\Program Files\R\R-4.2.0`
 (in an R session, this should be automatically set by R).
@@ -266,7 +172,7 @@ Note that the above prepends, rather than appends, because otherwise the wrong
 toolchain might be accidentally chosen if the `PATH` already contains another
 version of `R` or compiler toolchain.
 
-#### Tweak the toolchain
+### Tweak the toolchain
 
 As noted above, since the Rtools' toolchain is a bit different from the
 assumption of Rust, we need the following tweaks:
@@ -292,26 +198,22 @@ Cargo Book] about how this works.
 [The Cargo Book]: https://doc.rust-lang.org/cargo/reference/config.html#environment-variables
 
 The second tweak is also required. `rustc` adds `-lgcc_eh` and `-lgcc_s` flags
-to the compiler, but Rtools' GCC doesn't have `libgcc_eh` or `libgcc_a` due to
+to the compiler, but Rtools' GCC doesn't have `libgcc_eh` or `libgcc_s` due to
 the compilation settings. So, in order to please the compiler, we need to add
-empty `libgcc_eh` or `libgcc_a` to the library search paths. For more details,
+empty `libgcc_eh` or `libgcc_s` to the library search paths. For more details,
 please refer to [r-windows/rtools-packages].
 
 [r-windows/rtools-packages]: https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
 
-First, create a directory that contains empty `libgcc_eh` or `libgcc_a`.
+First, create a directory that contains empty `libgcc_eh` or `libgcc_s`.
 
 ``` ps1
 # create a directory in an arbitrary location (e.g. libgcc_mock)
 New-Item -Path libgcc_mock -Type Directory
 
-# compile an empty C file
-New-Item -Path libgcc_mock\gcc.c -Type File
-x86_64-w64-mingw32.static.posix-gcc.exe -c libgcc_mock\gcc.c -o libgcc_mock\gcc.o
-
 # create empty libgcc_eh.a and libgcc_s.a
-x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_eh.a libgcc_mock\gcc.o
-x86_64-w64-mingw32.static.posix-ar.exe -r libgcc_mock\libgcc_s.a libgcc_mock\gcc.o
+New-Item -Path libgcc_mock\libgcc_eh.a -Type File
+New-Item -Path libgcc_mock\libgcc_s.a -Type File
 ```
 
 Then, add the directory to `LIBRARY_PATH` envvar. For example, this can be done
@@ -321,88 +223,3 @@ by adding the following lines to `.cargo/config.toml`:
 [env]
 LIBRARY_PATH = "path/to/libgcc_mock"
 ```
-
-### Windows (R < 4.2)
-
-#### Install the `msvc` toolchain of Rust
-
-When building for `Windows` with older versions of R, the `msvc` toolchain and
-special `rust` targets should be added for compatibility with `R`:
-```Shell
-rustup toolchain install stable-msvc
-rustup target add x86_64-pc-windows-gnu  # 64-bit
-rustup target add   i686-pc-windows-gnu  # 32-bit
-```
-
-`stable-msvc` toolchain requires VS Build Tools. They are usually available on
-the systems with an installation of Visual Studio. Build tools can be obtained
-using an online [installer] (see also [these examples]) or using `chocolatey`.
-Required workflow components are:
-- Microsoft.VisualStudio.Component.VC.CoreBuildTools 
-- Microsoft.VisualStudio.Component.VC.Tools.x86.x64 
-- Microsoft.VisualStudio.Component.Windows10SDK.19041 (the latest version of the SDK available at the moment of writing this readme)
-
-[installer]: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019
-[these examples]: https://docs.microsoft.com/en-us/visualstudio/install/command-line-parameter-examples?view=vs-2019
-
-If there is an installation of VS (or Build Tools) on the system, launch `Visual
-Studio Installer` and ensure that either three required workflows are installed
-as individual components, or the whole `Desktop Development with C++` workflow
-pack is installed.
-
-If neither VS Build Tools nor Visual Studio itself are installed, all the
-necessary workflows can be easily obtained with the help of `chocolatey`:
-```Shell
-choco install visualstudio2019buildtools -y 
-choco install visualstudio2019-workload-vctools -y -f --package-parameters "--no-includeRecommended --add Microsoft.VisualStudio.Component.VC.CoreBuildTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041"  
-```
-
-#### Install Rtools40v2
-
-Rtools40 can be downloaded from [here][rtools40]. Alternatively, `Rtools` can be
-installed using `chocolatey`
-
-[rtools40]: https://cran.r-project.org/bin/windows/Rtools/rtools40.html
-
-```Shell
-choco install rtools --version=4.0.0.20220206 -y
-```
-
-Verify that the environment variable `RTOOLS40_HOME` is set up to point to the
-`Rtools` root.
-
-#### Setup `R_HOME` and  `PATH` envvars
-
-First, ensure that `R_HOME` points to `R` home, e.g. `C:\Program Files\R\R-4.1.0`
-(in an R session, this should be set by R).
-
-Second, ensure that `PATH` is properly configured that the following executables
-are available:
-
-* the `R` binary to build against
-* the compiler toolchain that is used for compiling the R itself, i.e., `Rtools`
-
-Typically, they can be found in the following locations (using `PowerShell` syntax):
-
-|         | R                         | Rtools                             |
-| ------- | ------------------------- | ---------------------------------- |
-| 64-bit  |  `$env:R_HOME\bin\x64`   | `$env:RTOOLS40_HOME\mingw64\bin` |
-| 32-bit  |  `$env:R_HOME\bin\i386`  | `$env:RTOOLS40_HOME\mingw32\bin` |
-
-
-Typically, the following paths need to be added to the head of `PATH` (using
-`PowerShell` syntax) for 64-bit R.
-
-```pwsh
-$env:PATH = "${env:R_HOME}\bin\x64;${env:RTOOLS40_HOME}\mingw64\bin;${env:PATH}"
-```
-
-and for 32-bit R.
-
-```pwsh
-$env:PATH = "${env:R_HOME}\bin\i386;${env:RTOOLS40_HOME}\mingw32\bin;${env:PATH}"
-```
-
-Note that the above prepends, rather than appends, because otherwise the wrong
-toolchain might be accidentally chosen if the `PATH` already contains another
-version of `R` or compiler toolchain.


### PR DESCRIPTION
Address #437

* Update README
  * Switch the Windows toolchain to MSVC
  * Move the documents about Windows with R 4.1 to another file so that we can just remove this when we drop support for R 4.1.
  * Remove the instruction about how to install VS Build Tools. I think Rust now installs it automatically, right...?
* Update CI settings to test both the MSVC and the GNU toolchain