### PR TITLE
Added `R_ext/Applic.h` to the bindings.

### DIFF
--- a/wrapper.h
+++ b/wrapper.h
@@ -29,3 +29,4 @@ typedef ptrdiff_t R_xlen_t_rust;
 #include <R_ext/Rdynload.h>
 #include <R_ext/Altrep.h>
 #include <R_ext/GraphicsEngine.h>
+#include <R_ext/Applic.h>


### PR DESCRIPTION
This was done as a request from a community member. We could add all R include files and generate the entire lot of the R-api, but for now this measured approach seems the most reasonable way forward.

Disregard the PR branch name. It was a misunderstanding on my part.