### PR TITLE
Add /bindings command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -399,8 +399,8 @@ jobs:
         
     - name: Push the generated bindings
       run: |
-        if [ "${GITHUB_EVENT_NAME}" = 'issue_comment' ]; then
-          GEN_TARGET_BRANCH="${GITHUB_HEAD_REF}"
+        if [ '${{ github.event_name }}' = 'issue_comment' ]; then
+          GEN_TARGET_BRANCH='${{ github.event.issue.pull_request.head_ref.name }}'
         else
           GEN_TARGET_BRANCH=generated_bindings
           # 1) If there's already generated_bindings branch, checkout it.
@@ -434,7 +434,7 @@ jobs:
           git commit -m "Update bindings [skip ci]"
           
           # cf. https://github.com/r-lib/actions/blob/ac4564fd0531646b1471781c2d4cdf83704cabf8/pr-push/src/main.ts#L26-L29
-          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}" "${GEN_TARGET_BRANCH}"
+          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.issue.pull_request.head_repository.name }}" "${GEN_TARGET_BRANCH}"
         else
           echo "No changes"
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -399,7 +399,7 @@ jobs:
         
     - name: Push the generated bindings
       run: |
-        if [ "${GITHUB_EVENT_NAME}" != 'issue_comment' ]; then
+        if [ "${GITHUB_EVENT_NAME}" = 'issue_comment' ]; then
           GEN_TARGET_BRANCH="${GITHUB_HEAD_REF}"
         else
           GEN_TARGET_BRANCH=generated_bindings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -432,7 +432,9 @@ jobs:
           git config --local user.name "${GITHUB_ACTOR}"
           git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git commit -m "Update bindings [skip ci]"
-          git push '${{ github.repositoryUrl }}' "${GEN_TARGET_BRANCH}"
+          
+          # cf. https://github.com/r-lib/actions/blob/ac4564fd0531646b1471781c2d4cdf83704cabf8/pr-push/src/main.ts#L26-L29
+          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}" "${GEN_TARGET_BRANCH}"
         else
           echo "No changes"
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
       - master
+  issue_comment:
+    types:
+      - created
   # Run this once per three days
   schedule:
     - cron: '29 17 */3 * *'
@@ -18,6 +21,16 @@ on:
 jobs:
 
   test_with_bindgen:
+    # When the event is not issue_comment, always run the tests. When it is,
+    # check if (1) the comment is on pull request, (2) the comment author is the
+    # member of the organization, and (3) the comment starts with '/bindings'.
+    #
+    # ref.
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment
+    if: |
+      github.event_name != 'issue_comment'
+      || (github.event.issue.pull_request && github.event.comment.author_association == 'MEMBER' && startsWith(github.event.comment.body, '/bindings'))
+
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }})
@@ -229,6 +242,9 @@ jobs:
           NO_TEST_TARGETS: ${{ join(matrix.config.no-test-targets, ',') }}
 
   test_windows_rtools:
+    # This doesn't need to be run on /bindings command
+    if: github.event_name != 'issue_comment'
+
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (R-${{ matrix.config.r }} rust-${{ matrix.config.rust-version }}) \w Rtools
@@ -372,8 +388,10 @@ jobs:
   commit_generated_bindings:
     needs: test_with_bindgen
     runs-on: ubuntu-latest
-    # Do not run this on pull request
-    if: github.ref == 'refs/heads/master'
+    # Run this only when the event is a push to the master or the /bindings command
+    if: |
+      (github.event_name != 'issue_comment' && github.ref == 'refs/heads/master')
+      || (github.event.comment && github.event.issue.pull_request && github.event.comment.author_association == 'MEMBER' && startsWith(github.event.comment.body, '/bindings'))
     steps:
     - uses: actions/checkout@v2
 
@@ -381,14 +399,20 @@ jobs:
         
     - name: Push the generated bindings
       run: |
-        # 1) If there's already generated_bindings branch, checkout it.
-        # 2) If generated_binding branch is not created, create it from the default branch.
-        if git ls-remote --exit-code --heads origin generated_bindings 2>&1 >/dev/null; then
-          git fetch origin --no-tags --prune --depth=1 generated_bindings
-          git checkout generated_bindings
+        if [ "${GITHUB_EVENT_NAME}" != 'issue_comment' ]; then
+          GEN_TARGET_BRANCH="${GITHUB_HEAD_REF}"
         else
-          git switch -c generated_bindings
+          GEN_TARGET_BRANCH=generated_bindings
+          # 1) If there's already generated_bindings branch, checkout it.
+          # 2) If generated_binding branch is not created, create it from the default branch.
+          if git ls-remote --exit-code --heads origin "${GEN_TARGET_BRANCH}" 2>&1 >/dev/null; then
+            git fetch origin --no-tags --prune --depth=1 "${GEN_TARGET_BRANCH}"
+            git checkout "${GEN_TARGET_BRANCH}"
+          else
+            git switch -c "${GEN_TARGET_BRANCH}"
+          fi
         fi
+
 
         # Update or add the bindings
         cp generated_binding-*/*.rs bindings/
@@ -408,7 +432,7 @@ jobs:
           git config --local user.name "${GITHUB_ACTOR}"
           git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git commit -m "Update bindings [skip ci]"
-          git push origin generated_bindings
+          git push '${{ github.repositoryUrl }}' "${GEN_TARGET_BRANCH}"
         else
           echo "No changes"
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -396,24 +396,27 @@ jobs:
     - uses: actions/checkout@v2
 
     - uses: actions/download-artifact@v2
-        
-    - name: Push the generated bindings
+
+    - name: Switch branch
+      if: github.event_name != 'issue_comment'
       run: |
-        if [ '${{ github.event_name }}' = 'issue_comment' ]; then
-          GEN_TARGET_BRANCH='${{ github.event.issue.pull_request.head_ref.name }}'
+        # 1) If there's already generated_bindings branch, checkout it.
+        # 2) If generated_binding branch is not created, create it from the default branch.
+        if git ls-remote --exit-code --heads origin generated_bindings 2>&1 >/dev/null; then
+          git fetch origin --no-tags --prune --depth=1 generated_bindings
+          git checkout generated_bindings
         else
-          GEN_TARGET_BRANCH=generated_bindings
-          # 1) If there's already generated_bindings branch, checkout it.
-          # 2) If generated_binding branch is not created, create it from the default branch.
-          if git ls-remote --exit-code --heads origin "${GEN_TARGET_BRANCH}" 2>&1 >/dev/null; then
-            git fetch origin --no-tags --prune --depth=1 "${GEN_TARGET_BRANCH}"
-            git checkout "${GEN_TARGET_BRANCH}"
-          else
-            git switch -c "${GEN_TARGET_BRANCH}"
-          fi
+          git switch -c generated_bindings
         fi
 
+    - name: Switch branch (/bindings command)
+      if: github.event_name == 'issue_comment'
+      uses: r-lib/actions/pr-fetch@v2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Commit the generated bindings
+      run: |
         # Update or add the bindings
         cp generated_binding-*/*.rs bindings/
 
@@ -431,10 +434,17 @@ jobs:
         if ! git diff-index --quiet HEAD -- bindings/; then
           git config --local user.name "${GITHUB_ACTOR}"
           git config --local user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git commit -m "Update bindings [skip ci]"
-          
-          # cf. https://github.com/r-lib/actions/blob/ac4564fd0531646b1471781c2d4cdf83704cabf8/pr-push/src/main.ts#L26-L29
-          git push "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.event.issue.pull_request.head_repository.name }}" "${GEN_TARGET_BRANCH}"
+          git commit -m "Update bindings [skip ci]"          
         else
           echo "No changes"
         fi
+
+    - name: Push
+      if: github.event_name != 'issue_comment'
+      run: git push origin generated_bindings
+
+    - name: Push (/bindings command)
+      if: github.event_name == 'issue_comment'
+      uses: r-lib/actions/pr-push@v2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -388,10 +388,10 @@ jobs:
   commit_generated_bindings:
     needs: test_with_bindgen
     runs-on: ubuntu-latest
-    # Run this only when the event is a push to the master or the /bindings command
-    if: |
-      (github.event_name != 'issue_comment' && github.ref == 'refs/heads/master')
-      || (github.event.comment && github.event.issue.pull_request && github.event.comment.author_association == 'MEMBER' && startsWith(github.event.comment.body, '/bindings'))
+    # In the case of /bindings command, we don't need to check anything else
+    # because it should have checked in test_with_bindings job. In the other
+    # cases, we only want to invoke this on the master branch.
+    if: github.event_name == 'issue_comment' || github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Close #129

This pull request allows us to generate bindings on a pull request by just commenting `/bindings`. But, this works only after this gets merged into the master branch, so it's a bit difficult to test this.