### PR TITLE
Use the branch of the pull request when /bindings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,16 @@ jobs:
     steps:
       
       - uses: actions/checkout@v3
+
+      # When invoked by an issue comment event, the GitHub Actions runner runs
+      # on the default branch, so we need to switch the branch of the pull
+      # request. Since the branch name is not easily accessible via variables
+      # provided GitHub Actions, we use r-lib/actions, which is well-maintained.
+      - name: Switch branch (/bindings command)
+        if: github.event_name == 'issue_comment'
+        uses: r-lib/actions/pr-fetch@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set up R
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
When invoked by an issue comment event, the GitHub Action runs on the default branch, not on the branch of the pull request. So, we have to switch to the branch explicitly, but it's not available as a form of variables pre-defined by GitHub Actions ([doc](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)). I thought I solved this problem by using `r-lib/actions/pr-fetch@v2` in https://github.com/extendr/libR-sys/pull/130, but I used this only on the step **after** building the bindings.

This pull request adds the switching step also to the `test_with_bindgen` job.