### PR TITLE
Add linux-aarch64 to the targets of auto-update on the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -441,7 +441,7 @@ jobs:
 
         # Replace the default bindings
         cd bindings
-        for x in linux-x86_64 macos-aarch64 macos-x86_64 windows-x86 windows-x86_64; do
+        for x in linux-aarch64 linux-x86_64 macos-aarch64 macos-x86_64 windows-x86 windows-x86_64; do
           # Choose the newest version except for devel
           ln --force -s "$(ls -1 ./bindings-${x}-*.rs | grep -v devel | sort | tail -1)" ./bindings-${x}.rs
         done


### PR DESCRIPTION
This is a small followup of https://github.com/extendr/libR-sys/pull/134. The CI automatically update the links of the default binding for each platform when `release` is bumped to a new version of R. I just forgot this mechanism when I reviewed https://github.com/extendr/libR-sys/pull/134, sorry.