### PR TITLE
Gather comments from headers

### DIFF
--- a/bindings/bindings-linux-aarch64-R4.1.rs
+++ b/bindings/bindings-linux-aarch64-R4.1.rs
@@ -100,12 +100,11 @@ pub const R_GE_patternExtendRepeat: u32 = 2;
 pub const R_GE_patternExtendReflect: u32 = 3;
 pub const R_GE_patternExtendNone: u32 = 4;
 pub const R_PROBLEM_BUFSIZE: u32 = 4096;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = [u64; 4usize];
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -123,54 +122,37 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
-    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
-    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
-    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
-    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
-    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
-    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
-    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
-    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
-    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -479,27 +461,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -614,7 +596,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -651,7 +633,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -674,7 +656,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -697,7 +679,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -730,7 +712,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -765,7 +747,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -786,7 +768,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
-#[doc = " called with a variable argument set"]
+#[doc = "called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -933,7 +915,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -956,7 +938,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -970,9 +952,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -984,7 +966,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the second USE_RINTERNALS section"]
+    #[doc = "Various tests with macro versions in the second USE_RINTERNALS section"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1012,7 +994,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1091,7 +1073,7 @@ extern "C" {
     pub fn MARK_ASSIGNMENT_CALL(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1101,7 +1083,7 @@ extern "C" {
     pub fn UNSET_S4_OBJECT(x: SEXP);
 }
 extern "C" {
-    #[doc = " JIT optimization support"]
+    #[doc = "JIT optimization support"]
     pub fn NOJIT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1117,14 +1099,14 @@ extern "C" {
     pub fn UNSET_MAYBEJIT(x: SEXP);
 }
 extern "C" {
-    #[doc = " Growable vector support"]
+    #[doc = "Growable vector support"]
     pub fn IS_GROWABLE(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SET_GROWABLE_BIT(x: SEXP);
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1198,7 +1180,7 @@ extern "C" {
     pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn STDVEC_DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -1263,7 +1245,7 @@ extern "C" {
     pub fn ALTVEC_EXTRACT_SUBSET(x: SEXP, indx: SEXP, call: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " data access"]
+    #[doc = "data access"]
     pub fn ALTINTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1325,7 +1307,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1350,7 +1332,7 @@ extern "C" {
     pub fn STRING_NO_NA(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " invoking ALTREP class methods"]
+    #[doc = "invoking ALTREP class methods"]
     pub fn ALTINTEGER_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1398,7 +1380,7 @@ extern "C" {
     pub fn ALTLOGICAL_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
-    #[doc = " constructors for internal ALTREP classes"]
+    #[doc = "constructors for internal ALTREP classes"]
     pub fn R_compact_intrange(n1: R_xlen_t, n2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1517,7 +1499,7 @@ extern "C" {
     pub fn CONS_NR(a: SEXP, b: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1554,7 +1536,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1579,7 +1561,7 @@ extern "C" {
     pub fn SET_INTERNAL(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1604,7 +1586,7 @@ extern "C" {
     pub fn SET_HASHTAB(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Promise Access Functions */\n/* First five have macro versions in Defn.h"]
+    #[doc = "Promise Access Functions */\n/* First five have macro versions in Defn.h"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1629,7 +1611,7 @@ extern "C" {
     pub fn SET_PRCODE(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Hashing Functions */\n/* There are macro versions in Defn.h"]
+    #[doc = "Hashing Functions */\n/* There are macro versions in Defn.h"]
     pub fn HASHASH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1641,229 +1623,229 @@ extern "C" {
 extern "C" {
     pub fn SET_HASHVALUE(x: SEXP, v: ::std::os::raw::c_int);
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1909,7 +1891,7 @@ pub const warn_type_iWARN: warn_type = 1;
 pub const warn_type_iERROR: warn_type = 2;
 pub type warn_type = ::std::os::raw::c_uint;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2047,7 +2029,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2200,7 +2182,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -2331,7 +2313,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2355,11 +2337,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2384,13 +2366,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2408,7 +2390,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2457,7 +2439,7 @@ extern "C" {
     pub fn R_reinit_altrep_classes(arg1: *mut DllInfo);
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2528,7 +2510,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2908,7 +2890,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2918,11 +2900,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2944,7 +2926,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2958,7 +2940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2977,7 +2959,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2987,14 +2969,14 @@ extern "C" {
     pub fn R_system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
+    #[doc = "R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -3004,7 +2986,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -3330,11 +3312,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " TRUE during interactive use"]
+    #[doc = "TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
-    #[doc = " do not echo R code"]
+    #[doc = "do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3362,7 +3344,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Current image dirty"]
+    #[doc = "Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3372,19 +3354,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
-    #[doc = " Name of the history file"]
+    #[doc = "Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Size of the history file"]
+    #[doc = "Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " restore the history file?"]
+    #[doc = "restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Root of the R tree"]
+    #[doc = "Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3400,7 +3382,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
-    #[doc = " Need opaque pointer type for export"]
+    #[doc = "Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3419,34 +3401,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
-    #[doc = " in ../unix/sys-unix.c"]
+    #[doc = "in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
-    #[doc = " in ../unix/system.c"]
+    #[doc = "in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
-    #[doc = " Initial stack address"]
+    #[doc = "Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
-#[doc = " = 0"]
+#[doc = "= 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
-#[doc = " was === SA_RESTORE"]
+#[doc = "was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
-#[doc = " Startup Actions"]
+#[doc = "Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3754,7 +3736,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
-    #[doc = " added in 3.0.0"]
+    #[doc = "added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3765,7 +3747,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[doc = " naming follows earlier versions in R.app"]
+    #[doc = "naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3784,7 +3766,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
-    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
+    #[doc = "These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3828,14 +3810,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4605,7 +4587,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4972,73 +4954,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -5197,67 +5179,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5363,12 +5345,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5389,24 +5371,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5417,11 +5399,11 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -6196,7 +6178,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6246,12 +6228,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6304,7 +6286,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6314,9 +6296,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6357,23 +6339,23 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
 }
 #[test]
@@ -6567,7 +6549,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6734,7 +6716,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6796,7 +6778,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6825,7 +6807,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6837,7 +6819,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6923,7 +6905,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -7002,7 +6984,7 @@ extern "C" {
     pub fn R_GE_tilingPatternExtend(pattern: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7880,12 +7862,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7923,7 +7905,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8089,7 +8071,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -8101,7 +8083,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8110,7 +8092,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8136,7 +8118,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8212,11 +8194,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-aarch64-R4.1.rs
+++ b/bindings/bindings-linux-aarch64-R4.1.rs
@@ -100,11 +100,12 @@ pub const R_GE_patternExtendRepeat: u32 = 2;
 pub const R_GE_patternExtendReflect: u32 = 3;
 pub const R_GE_patternExtendNone: u32 = 4;
 pub const R_PROBLEM_BUFSIZE: u32 = 4096;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = [u64; 4usize];
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -122,37 +123,54 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
+    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
+    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
+    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
+    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
+    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
+    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
+    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
+    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -461,21 +479,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -484,7 +508,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -588,6 +614,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -624,6 +651,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -646,6 +674,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -668,6 +697,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -700,6 +730,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -734,6 +765,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -754,8 +786,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
+#[doc = " called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -819,6 +853,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -898,6 +933,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -920,6 +956,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -933,7 +970,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -945,6 +984,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the second USE_RINTERNALS section"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -972,6 +1012,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1050,6 +1091,7 @@ extern "C" {
     pub fn MARK_ASSIGNMENT_CALL(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1059,6 +1101,7 @@ extern "C" {
     pub fn UNSET_S4_OBJECT(x: SEXP);
 }
 extern "C" {
+    #[doc = " JIT optimization support"]
     pub fn NOJIT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1074,12 +1117,14 @@ extern "C" {
     pub fn UNSET_MAYBEJIT(x: SEXP);
 }
 extern "C" {
+    #[doc = " Growable vector support"]
     pub fn IS_GROWABLE(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SET_GROWABLE_BIT(x: SEXP);
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1134,6 +1179,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1152,6 +1198,7 @@ extern "C" {
     pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn STDVEC_DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -1216,6 +1263,7 @@ extern "C" {
     pub fn ALTVEC_EXTRACT_SUBSET(x: SEXP, indx: SEXP, call: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " data access"]
     pub fn ALTINTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1277,6 +1325,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1301,6 +1350,7 @@ extern "C" {
     pub fn STRING_NO_NA(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " invoking ALTREP class methods"]
     pub fn ALTINTEGER_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1348,6 +1398,7 @@ extern "C" {
     pub fn ALTLOGICAL_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
+    #[doc = " constructors for internal ALTREP classes"]
     pub fn R_compact_intrange(n1: R_xlen_t, n2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1466,6 +1517,7 @@ extern "C" {
     pub fn CONS_NR(a: SEXP, b: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1502,6 +1554,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1526,6 +1579,7 @@ extern "C" {
     pub fn SET_INTERNAL(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1550,6 +1604,7 @@ extern "C" {
     pub fn SET_HASHTAB(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Promise Access Functions */\n/* First five have macro versions in Defn.h"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1574,6 +1629,7 @@ extern "C" {
     pub fn SET_PRCODE(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Hashing Functions */\n/* There are macro versions in Defn.h"]
     pub fn HASHASH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1585,173 +1641,229 @@ extern "C" {
 extern "C" {
     pub fn SET_HASHVALUE(x: SEXP, v: ::std::os::raw::c_int);
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1797,6 +1909,7 @@ pub const warn_type_iWARN: warn_type = 1;
 pub const warn_type_iERROR: warn_type = 2;
 pub type warn_type = ::std::os::raw::c_uint;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1934,6 +2047,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2086,6 +2200,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -2216,6 +2331,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2239,9 +2355,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2266,11 +2384,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2288,6 +2408,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2336,6 +2457,7 @@ extern "C" {
     pub fn R_reinit_altrep_classes(arg1: *mut DllInfo);
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2406,6 +2528,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2785,6 +2908,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2794,9 +2918,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2818,6 +2944,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2831,6 +2958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2849,6 +2977,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2858,12 +2987,14 @@ extern "C" {
     pub fn R_system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2873,6 +3004,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2882,6 +3014,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the inlinable functions that are provided in Rinlinedfuns.h\nIt is *essential* that these do not appear in any other header file,\nwith or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -3197,9 +3330,11 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
+    #[doc = " do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3227,6 +3362,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3236,15 +3372,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
+    #[doc = " Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3260,6 +3400,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
+    #[doc = " Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3278,27 +3419,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
+    #[doc = " in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
+    #[doc = " in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
+    #[doc = " Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
+#[doc = " = 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
+#[doc = " was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
+#[doc = " Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3606,6 +3754,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
+    #[doc = " added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3616,6 +3765,7 @@ extern "C" {
     >;
 }
 extern "C" {
+    #[doc = " naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3634,6 +3784,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
+    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3677,12 +3828,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4452,6 +4605,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4818,45 +4972,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -5015,47 +5197,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5161,10 +5363,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5185,17 +5389,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5206,8 +5417,11 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5982,6 +6196,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6031,10 +6246,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6087,6 +6304,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6096,7 +6314,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6137,14 +6357,23 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
 }
 #[test]
@@ -6326,6 +6555,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -6337,6 +6567,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6496,12 +6727,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6563,6 +6796,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6591,6 +6825,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6602,6 +6837,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6687,6 +6923,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6765,6 +7002,7 @@ extern "C" {
     pub fn R_GE_tilingPatternExtend(pattern: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7642,10 +7880,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7683,6 +7923,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7848,6 +8089,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7859,6 +8101,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7867,6 +8110,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7892,6 +8136,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7967,9 +8212,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-aarch64-R4.2.rs
+++ b/bindings/bindings-linux-aarch64-R4.2.rs
@@ -230,11 +230,12 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = [u64; 4usize];
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -252,37 +253,54 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
+    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
+    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
+    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
+    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
+    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
+    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
+    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
+    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -591,21 +609,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -614,7 +638,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -718,6 +744,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -754,6 +781,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -776,6 +804,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -798,6 +827,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -830,6 +860,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -864,6 +895,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -884,8 +916,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
+#[doc = " called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -949,6 +983,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1028,6 +1063,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1050,6 +1086,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1063,7 +1100,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1075,6 +1114,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1102,6 +1142,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1132,9 +1173,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1180,6 +1223,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1223,6 +1267,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1301,6 +1346,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1337,6 +1383,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1349,6 +1396,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1361,6 +1409,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1373,6 +1422,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1381,176 +1431,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1584,6 +1691,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1668,6 +1776,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1787,6 +1896,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1869,6 +1979,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1892,9 +2003,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1919,11 +2032,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1941,6 +2056,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1965,6 +2081,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2035,6 +2152,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2411,6 +2529,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2420,9 +2539,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2444,6 +2565,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2457,6 +2579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2475,6 +2598,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2490,6 +2614,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2499,6 +2624,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2508,6 +2634,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the public inlinable functions that are provided in\nRinlinedfuns.h It is *essential* that these do not appear in any\nother header file, with or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2754,6 +2881,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2786,6 +2914,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
+#[doc = " try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2817,6 +2946,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
+    #[doc = " public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2860,6 +2990,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
+    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2927,12 +3058,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
+    #[doc = " do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -2960,6 +3094,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2969,15 +3104,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
+    #[doc = " Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2993,6 +3132,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
+    #[doc = " Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3011,27 +3151,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
+    #[doc = " in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
+    #[doc = " in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
+    #[doc = " Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
+#[doc = " = 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
+#[doc = " was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
+#[doc = " Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3257,6 +3404,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3377,6 +3525,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
+    #[doc = " added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3387,6 +3536,7 @@ extern "C" {
     >;
 }
 extern "C" {
+    #[doc = " naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3405,6 +3555,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
+    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3448,12 +3599,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4232,6 +4385,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4598,45 +4752,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4795,47 +4977,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4941,10 +5143,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4965,17 +5169,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4986,7 +5197,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5008,6 +5221,7 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5852,6 +6066,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5901,10 +6116,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5957,6 +6174,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5966,7 +6184,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6007,15 +6227,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
+    #[doc = " Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6207,6 +6437,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -6218,6 +6449,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6377,12 +6609,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6444,6 +6678,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6472,6 +6707,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6483,6 +6719,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6568,6 +6805,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6661,6 +6899,7 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7526,10 +7765,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7567,6 +7808,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7732,6 +7974,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7743,6 +7986,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7751,6 +7995,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7776,6 +8021,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7851,9 +8097,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-aarch64-R4.2.rs
+++ b/bindings/bindings-linux-aarch64-R4.2.rs
@@ -230,12 +230,11 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = [u64; 4usize];
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -253,54 +252,37 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
-    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
-    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
-    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
-    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
-    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
-    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
-    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
-    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
-    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -609,27 +591,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -744,7 +726,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -781,7 +763,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -804,7 +786,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -827,7 +809,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -860,7 +842,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -895,7 +877,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -916,7 +898,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
-#[doc = " called with a variable argument set"]
+#[doc = "called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -1063,7 +1045,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1086,7 +1068,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1100,9 +1082,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1114,7 +1096,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the internal headers"]
+    #[doc = "Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1142,7 +1124,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1173,11 +1155,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1267,7 +1249,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1346,7 +1328,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1383,7 +1365,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1396,7 +1378,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1409,7 +1391,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Promise Access Functions"]
+    #[doc = "Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1422,7 +1404,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " External pointer access macros"]
+    #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1431,233 +1413,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"@\""]
+    #[doc = "\"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1691,7 +1673,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1776,7 +1758,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1896,7 +1878,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1979,7 +1961,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2003,11 +1985,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2032,13 +2014,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2056,7 +2038,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2081,7 +2063,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2152,7 +2134,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2529,7 +2511,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2539,11 +2521,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2565,7 +2547,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2579,7 +2561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2598,7 +2580,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2614,7 +2596,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2624,7 +2606,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2881,7 +2863,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2914,7 +2896,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
-#[doc = " try to allow some type checking"]
+#[doc = "try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2946,7 +2928,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
-    #[doc = " public C interface"]
+    #[doc = "public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2990,7 +2972,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
-    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
+    #[doc = "stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -3058,15 +3040,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
+    #[doc = "used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " TRUE during interactive use"]
+    #[doc = "TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
-    #[doc = " do not echo R code"]
+    #[doc = "do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3094,7 +3076,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Current image dirty"]
+    #[doc = "Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3104,19 +3086,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
-    #[doc = " Name of the history file"]
+    #[doc = "Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Size of the history file"]
+    #[doc = "Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " restore the history file?"]
+    #[doc = "restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Root of the R tree"]
+    #[doc = "Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3132,7 +3114,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
-    #[doc = " Need opaque pointer type for export"]
+    #[doc = "Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3151,34 +3133,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
-    #[doc = " in ../unix/sys-unix.c"]
+    #[doc = "in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
-    #[doc = " in ../unix/system.c"]
+    #[doc = "in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
-    #[doc = " Initial stack address"]
+    #[doc = "Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
-#[doc = " = 0"]
+#[doc = "= 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
-#[doc = " was === SA_RESTORE"]
+#[doc = "was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
-#[doc = " Startup Actions"]
+#[doc = "Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3404,7 +3386,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
+    #[doc = "New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3525,7 +3507,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
-    #[doc = " added in 3.0.0"]
+    #[doc = "added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3536,7 +3518,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[doc = " naming follows earlier versions in R.app"]
+    #[doc = "naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3555,7 +3537,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
-    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
+    #[doc = "These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3599,14 +3581,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4385,7 +4367,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4752,73 +4734,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4977,67 +4959,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5143,12 +5125,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5169,24 +5151,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5197,9 +5179,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5221,7 +5203,7 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -6066,7 +6048,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6116,12 +6098,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6174,7 +6156,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6184,9 +6166,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6227,25 +6209,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
-    #[doc = " Is a device appending a path ?"]
+    #[doc = "Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6449,7 +6431,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6616,7 +6598,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6678,7 +6660,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6707,7 +6689,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6719,7 +6701,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6805,7 +6787,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6899,7 +6881,7 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7765,12 +7747,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7808,7 +7790,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7974,7 +7956,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7986,7 +7968,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7995,7 +7977,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8021,7 +8003,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8097,11 +8079,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-aarch64-R4.3-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.3-devel.rs
@@ -163,8 +163,8 @@ pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
 pub const R_MONTH: &[u8; 3usize] = b"02\0";
-pub const R_DAY: &[u8; 3usize] = b"21\0";
-pub const R_SVN_REVISION: u32 = 83888;
+pub const R_DAY: &[u8; 3usize] = b"26\0";
+pub const R_SVN_REVISION: u32 = 83908;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
@@ -235,11 +235,12 @@ pub const R_GE_capability_glyphs: u32 = 12;
 pub const R_GE_text_style_normal: u32 = 1;
 pub const R_GE_text_style_italic: u32 = 2;
 pub const R_GE_text_style_oblique: u32 = 3;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = [u64; 4usize];
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -257,37 +258,54 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
+    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
+    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
+    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
+    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
+    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
+    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
+    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
+    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -596,21 +614,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -619,7 +643,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -723,6 +749,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -759,6 +786,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -781,6 +809,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -803,6 +832,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -835,6 +865,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -869,6 +900,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -889,8 +921,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
+#[doc = " Called with a variable argument set after casting to a compatible\nfunction pointer."]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -954,6 +988,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1033,6 +1068,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1055,6 +1091,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1068,7 +1105,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1080,6 +1119,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1107,6 +1147,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1137,9 +1178,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1185,6 +1228,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1228,6 +1272,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1309,6 +1354,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1345,6 +1391,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1357,6 +1404,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1369,6 +1417,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1381,6 +1430,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1389,176 +1439,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1592,6 +1699,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1676,6 +1784,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1795,6 +1904,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1877,6 +1987,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1908,9 +2019,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1935,11 +2048,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1957,6 +2072,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1981,6 +2097,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2051,6 +2168,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2099,6 +2217,7 @@ extern "C" {
     pub fn R_HasFancyBindings(rho: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " ../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
     pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
@@ -2427,6 +2546,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2436,9 +2556,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2460,6 +2582,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2473,6 +2596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2491,6 +2615,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2506,6 +2631,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2515,6 +2641,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2524,6 +2651,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the public inlinable functions that are provided in\nRinlinedfuns.h It is *essential* that these do not appear in any\nother header file, with or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2770,6 +2898,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2802,6 +2931,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
+#[doc = " try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2833,6 +2963,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
+    #[doc = " public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2876,6 +3007,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
+    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2943,12 +3075,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
+    #[doc = " do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -2976,6 +3111,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2985,15 +3121,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
+    #[doc = " Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3009,6 +3149,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
+    #[doc = " Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3027,27 +3168,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
+    #[doc = " in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
+    #[doc = " in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
+    #[doc = " Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
+#[doc = " = 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
+#[doc = " was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
+#[doc = " Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3273,6 +3421,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3393,6 +3542,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
+    #[doc = " added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3403,6 +3553,7 @@ extern "C" {
     >;
 }
 extern "C" {
+    #[doc = " naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3421,6 +3572,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
+    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3464,12 +3616,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4248,6 +4402,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4614,45 +4769,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4811,47 +4994,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4957,10 +5160,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4981,17 +5186,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5002,7 +5214,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5037,6 +5251,7 @@ pub struct _DevDesc {
             dd: pDevDesc,
         ),
     >,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5891,6 +6106,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5940,10 +6156,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5996,6 +6214,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6005,7 +6224,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6046,15 +6267,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
+    #[doc = " Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6246,6 +6477,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -6257,6 +6489,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6416,12 +6649,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6483,6 +6718,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6511,6 +6747,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6522,6 +6759,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6607,6 +6845,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6755,6 +6994,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7712,10 +7952,12 @@ extern "C" {
         arg3: usize,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7753,6 +7995,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7918,6 +8161,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7929,6 +8173,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7937,6 +8182,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7962,6 +8208,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8037,9 +8284,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-aarch64-R4.3-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.3-devel.rs
@@ -235,12 +235,11 @@ pub const R_GE_capability_glyphs: u32 = 12;
 pub const R_GE_text_style_normal: u32 = 1;
 pub const R_GE_text_style_italic: u32 = 2;
 pub const R_GE_text_style_oblique: u32 = 3;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = [u64; 4usize];
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -258,54 +257,37 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
-    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
-    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
-    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
-    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
-    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
-    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
-    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
-    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
-    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -614,27 +596,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -749,7 +731,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -786,7 +768,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -809,7 +791,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -832,7 +814,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -865,7 +847,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -900,7 +882,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -921,7 +903,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
-#[doc = " Called with a variable argument set after casting to a compatible\nfunction pointer."]
+#[doc = "Called with a variable argument set after casting to a compatible\nfunction pointer."]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -1068,7 +1050,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1091,7 +1073,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1105,9 +1087,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1119,7 +1101,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the internal headers"]
+    #[doc = "Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1147,7 +1129,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1178,11 +1160,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1272,7 +1254,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1354,7 +1336,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1391,7 +1373,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1404,7 +1386,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1417,7 +1399,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Promise Access Functions"]
+    #[doc = "Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1430,7 +1412,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " External pointer access macros"]
+    #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1439,233 +1421,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"@\""]
+    #[doc = "\"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1699,7 +1681,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1784,7 +1766,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1904,7 +1886,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1987,7 +1969,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2019,11 +2001,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2048,13 +2030,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2072,7 +2054,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2097,7 +2079,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2168,7 +2150,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2217,7 +2199,7 @@ extern "C" {
     pub fn R_HasFancyBindings(rho: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " ../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
+    #[doc = "../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
     pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
@@ -2546,7 +2528,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2556,11 +2538,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2582,7 +2564,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2596,7 +2578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2615,7 +2597,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2631,7 +2613,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2641,7 +2623,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2898,7 +2880,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2931,7 +2913,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
-#[doc = " try to allow some type checking"]
+#[doc = "try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2963,7 +2945,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
-    #[doc = " public C interface"]
+    #[doc = "public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -3007,7 +2989,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
-    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
+    #[doc = "stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -3075,15 +3057,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
+    #[doc = "used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " TRUE during interactive use"]
+    #[doc = "TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
-    #[doc = " do not echo R code"]
+    #[doc = "do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3111,7 +3093,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Current image dirty"]
+    #[doc = "Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3121,19 +3103,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
-    #[doc = " Name of the history file"]
+    #[doc = "Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Size of the history file"]
+    #[doc = "Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " restore the history file?"]
+    #[doc = "restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Root of the R tree"]
+    #[doc = "Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3149,7 +3131,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
-    #[doc = " Need opaque pointer type for export"]
+    #[doc = "Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3168,34 +3150,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
-    #[doc = " in ../unix/sys-unix.c"]
+    #[doc = "in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
-    #[doc = " in ../unix/system.c"]
+    #[doc = "in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
-    #[doc = " Initial stack address"]
+    #[doc = "Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
-#[doc = " = 0"]
+#[doc = "= 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
-#[doc = " was === SA_RESTORE"]
+#[doc = "was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
-#[doc = " Startup Actions"]
+#[doc = "Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3421,7 +3403,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
+    #[doc = "New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3542,7 +3524,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
-    #[doc = " added in 3.0.0"]
+    #[doc = "added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3553,7 +3535,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[doc = " naming follows earlier versions in R.app"]
+    #[doc = "naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3572,7 +3554,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
-    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
+    #[doc = "These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3616,14 +3598,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4402,7 +4384,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4769,73 +4751,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4994,67 +4976,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5160,12 +5142,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5186,24 +5168,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5214,9 +5196,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5251,7 +5233,7 @@ pub struct _DevDesc {
             dd: pDevDesc,
         ),
     >,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -6106,7 +6088,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6156,12 +6138,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6214,7 +6196,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6224,9 +6206,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6267,25 +6249,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
-    #[doc = " Is a device appending a path ?"]
+    #[doc = "Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6489,7 +6471,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6656,7 +6638,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6718,7 +6700,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6747,7 +6729,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6759,7 +6741,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6845,7 +6827,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6994,7 +6976,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7952,12 +7934,12 @@ extern "C" {
         arg3: usize,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7995,7 +7977,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8161,7 +8143,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -8173,7 +8155,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8182,7 +8164,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8208,7 +8190,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8284,11 +8266,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-x86_64-R4.1.rs
+++ b/bindings/bindings-linux-x86_64-R4.1.rs
@@ -100,11 +100,12 @@ pub const R_GE_patternExtendRepeat: u32 = 2;
 pub const R_GE_patternExtendReflect: u32 = 3;
 pub const R_GE_patternExtendNone: u32 = 4;
 pub const R_PROBLEM_BUFSIZE: u32 = 4096;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = __builtin_va_list;
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -122,37 +123,54 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
+    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
+    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
+    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
+    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
+    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
+    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
+    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
+    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -461,21 +479,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -484,7 +508,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -588,6 +614,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -624,6 +651,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -646,6 +674,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -668,6 +697,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -700,6 +730,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -734,6 +765,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -754,8 +786,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
+#[doc = " called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -819,6 +853,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -898,6 +933,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -920,6 +956,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -933,7 +970,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -945,6 +984,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the second USE_RINTERNALS section"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -972,6 +1012,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1050,6 +1091,7 @@ extern "C" {
     pub fn MARK_ASSIGNMENT_CALL(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1059,6 +1101,7 @@ extern "C" {
     pub fn UNSET_S4_OBJECT(x: SEXP);
 }
 extern "C" {
+    #[doc = " JIT optimization support"]
     pub fn NOJIT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1074,12 +1117,14 @@ extern "C" {
     pub fn UNSET_MAYBEJIT(x: SEXP);
 }
 extern "C" {
+    #[doc = " Growable vector support"]
     pub fn IS_GROWABLE(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SET_GROWABLE_BIT(x: SEXP);
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1134,6 +1179,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1152,6 +1198,7 @@ extern "C" {
     pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn STDVEC_DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -1216,6 +1263,7 @@ extern "C" {
     pub fn ALTVEC_EXTRACT_SUBSET(x: SEXP, indx: SEXP, call: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " data access"]
     pub fn ALTINTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1277,6 +1325,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1301,6 +1350,7 @@ extern "C" {
     pub fn STRING_NO_NA(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " invoking ALTREP class methods"]
     pub fn ALTINTEGER_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1348,6 +1398,7 @@ extern "C" {
     pub fn ALTLOGICAL_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
+    #[doc = " constructors for internal ALTREP classes"]
     pub fn R_compact_intrange(n1: R_xlen_t, n2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1466,6 +1517,7 @@ extern "C" {
     pub fn CONS_NR(a: SEXP, b: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1502,6 +1554,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1526,6 +1579,7 @@ extern "C" {
     pub fn SET_INTERNAL(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1550,6 +1604,7 @@ extern "C" {
     pub fn SET_HASHTAB(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Promise Access Functions */\n/* First five have macro versions in Defn.h"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1574,6 +1629,7 @@ extern "C" {
     pub fn SET_PRCODE(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Hashing Functions */\n/* There are macro versions in Defn.h"]
     pub fn HASHASH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1585,173 +1641,229 @@ extern "C" {
 extern "C" {
     pub fn SET_HASHVALUE(x: SEXP, v: ::std::os::raw::c_int);
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1797,6 +1909,7 @@ pub const warn_type_iWARN: warn_type = 1;
 pub const warn_type_iERROR: warn_type = 2;
 pub type warn_type = ::std::os::raw::c_uint;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1934,6 +2047,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2086,6 +2200,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -2216,6 +2331,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2239,9 +2355,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2266,11 +2384,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2288,6 +2408,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2336,6 +2457,7 @@ extern "C" {
     pub fn R_reinit_altrep_classes(arg1: *mut DllInfo);
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2406,6 +2528,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2785,6 +2908,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2794,9 +2918,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2818,6 +2944,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2831,6 +2958,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2849,6 +2977,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2858,12 +2987,14 @@ extern "C" {
     pub fn R_system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2873,6 +3004,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2882,6 +3014,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the inlinable functions that are provided in Rinlinedfuns.h\nIt is *essential* that these do not appear in any other header file,\nwith or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -3197,9 +3330,11 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
+    #[doc = " do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3227,6 +3362,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3236,15 +3372,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
+    #[doc = " Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3260,6 +3400,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
+    #[doc = " Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3278,27 +3419,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
+    #[doc = " in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
+    #[doc = " in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
+    #[doc = " Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
+#[doc = " = 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
+#[doc = " was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
+#[doc = " Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3606,6 +3754,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
+    #[doc = " added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3616,6 +3765,7 @@ extern "C" {
     >;
 }
 extern "C" {
+    #[doc = " naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3634,6 +3784,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
+    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3677,12 +3828,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4452,6 +4605,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4818,45 +4972,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -5015,47 +5197,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5161,10 +5363,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5185,17 +5389,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5206,8 +5417,11 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5982,6 +6196,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6031,10 +6246,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6087,6 +6304,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6096,7 +6314,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6137,14 +6357,23 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
 }
 #[test]
@@ -6326,6 +6555,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -6337,6 +6567,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6496,12 +6727,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6563,6 +6796,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6591,6 +6825,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6602,6 +6837,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6687,6 +6923,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6765,6 +7002,7 @@ extern "C" {
     pub fn R_GE_tilingPatternExtend(pattern: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7642,10 +7880,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7683,6 +7923,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7848,6 +8089,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7859,6 +8101,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7867,6 +8110,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7892,6 +8136,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7967,9 +8212,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-x86_64-R4.1.rs
+++ b/bindings/bindings-linux-x86_64-R4.1.rs
@@ -100,12 +100,11 @@ pub const R_GE_patternExtendRepeat: u32 = 2;
 pub const R_GE_patternExtendReflect: u32 = 3;
 pub const R_GE_patternExtendNone: u32 = 4;
 pub const R_PROBLEM_BUFSIZE: u32 = 4096;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = __builtin_va_list;
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -123,54 +122,37 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
-    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
-    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
-    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
-    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
-    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
-    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
-    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
-    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
-    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -479,27 +461,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -614,7 +596,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -651,7 +633,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -674,7 +656,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -697,7 +679,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -730,7 +712,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -765,7 +747,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -786,7 +768,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
-#[doc = " called with a variable argument set"]
+#[doc = "called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -933,7 +915,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -956,7 +938,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -970,9 +952,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -984,7 +966,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the second USE_RINTERNALS section"]
+    #[doc = "Various tests with macro versions in the second USE_RINTERNALS section"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1012,7 +994,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1091,7 +1073,7 @@ extern "C" {
     pub fn MARK_ASSIGNMENT_CALL(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1101,7 +1083,7 @@ extern "C" {
     pub fn UNSET_S4_OBJECT(x: SEXP);
 }
 extern "C" {
-    #[doc = " JIT optimization support"]
+    #[doc = "JIT optimization support"]
     pub fn NOJIT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1117,14 +1099,14 @@ extern "C" {
     pub fn UNSET_MAYBEJIT(x: SEXP);
 }
 extern "C" {
-    #[doc = " Growable vector support"]
+    #[doc = "Growable vector support"]
     pub fn IS_GROWABLE(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SET_GROWABLE_BIT(x: SEXP);
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1198,7 +1180,7 @@ extern "C" {
     pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn STDVEC_DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -1263,7 +1245,7 @@ extern "C" {
     pub fn ALTVEC_EXTRACT_SUBSET(x: SEXP, indx: SEXP, call: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " data access"]
+    #[doc = "data access"]
     pub fn ALTINTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1325,7 +1307,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1350,7 +1332,7 @@ extern "C" {
     pub fn STRING_NO_NA(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " invoking ALTREP class methods"]
+    #[doc = "invoking ALTREP class methods"]
     pub fn ALTINTEGER_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1398,7 +1380,7 @@ extern "C" {
     pub fn ALTLOGICAL_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
-    #[doc = " constructors for internal ALTREP classes"]
+    #[doc = "constructors for internal ALTREP classes"]
     pub fn R_compact_intrange(n1: R_xlen_t, n2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1517,7 +1499,7 @@ extern "C" {
     pub fn CONS_NR(a: SEXP, b: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1554,7 +1536,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1579,7 +1561,7 @@ extern "C" {
     pub fn SET_INTERNAL(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1604,7 +1586,7 @@ extern "C" {
     pub fn SET_HASHTAB(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Promise Access Functions */\n/* First five have macro versions in Defn.h"]
+    #[doc = "Promise Access Functions */\n/* First five have macro versions in Defn.h"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1629,7 +1611,7 @@ extern "C" {
     pub fn SET_PRCODE(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Hashing Functions */\n/* There are macro versions in Defn.h"]
+    #[doc = "Hashing Functions */\n/* There are macro versions in Defn.h"]
     pub fn HASHASH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1641,229 +1623,229 @@ extern "C" {
 extern "C" {
     pub fn SET_HASHVALUE(x: SEXP, v: ::std::os::raw::c_int);
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1909,7 +1891,7 @@ pub const warn_type_iWARN: warn_type = 1;
 pub const warn_type_iERROR: warn_type = 2;
 pub type warn_type = ::std::os::raw::c_uint;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2047,7 +2029,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2200,7 +2182,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -2331,7 +2313,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2355,11 +2337,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2384,13 +2366,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2408,7 +2390,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2457,7 +2439,7 @@ extern "C" {
     pub fn R_reinit_altrep_classes(arg1: *mut DllInfo);
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2528,7 +2510,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2908,7 +2890,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2918,11 +2900,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2944,7 +2926,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2958,7 +2940,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2977,7 +2959,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2987,14 +2969,14 @@ extern "C" {
     pub fn R_system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
+    #[doc = "R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -3004,7 +2986,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -3330,11 +3312,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " TRUE during interactive use"]
+    #[doc = "TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
-    #[doc = " do not echo R code"]
+    #[doc = "do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3362,7 +3344,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Current image dirty"]
+    #[doc = "Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3372,19 +3354,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
-    #[doc = " Name of the history file"]
+    #[doc = "Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Size of the history file"]
+    #[doc = "Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " restore the history file?"]
+    #[doc = "restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Root of the R tree"]
+    #[doc = "Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3400,7 +3382,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
-    #[doc = " Need opaque pointer type for export"]
+    #[doc = "Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3419,34 +3401,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
-    #[doc = " in ../unix/sys-unix.c"]
+    #[doc = "in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
-    #[doc = " in ../unix/system.c"]
+    #[doc = "in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
-    #[doc = " Initial stack address"]
+    #[doc = "Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
-#[doc = " = 0"]
+#[doc = "= 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
-#[doc = " was === SA_RESTORE"]
+#[doc = "was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
-#[doc = " Startup Actions"]
+#[doc = "Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3754,7 +3736,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
-    #[doc = " added in 3.0.0"]
+    #[doc = "added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3765,7 +3747,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[doc = " naming follows earlier versions in R.app"]
+    #[doc = "naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3784,7 +3766,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
-    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
+    #[doc = "These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3828,14 +3810,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4605,7 +4587,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4972,73 +4954,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -5197,67 +5179,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5363,12 +5345,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5389,24 +5371,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5417,11 +5399,11 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -6196,7 +6178,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6246,12 +6228,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6304,7 +6286,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6314,9 +6296,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6357,23 +6339,23 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
 }
 #[test]
@@ -6567,7 +6549,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6734,7 +6716,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6796,7 +6778,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6825,7 +6807,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6837,7 +6819,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6923,7 +6905,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -7002,7 +6984,7 @@ extern "C" {
     pub fn R_GE_tilingPatternExtend(pattern: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7880,12 +7862,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7923,7 +7905,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8089,7 +8071,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -8101,7 +8083,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8110,7 +8092,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8136,7 +8118,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8212,11 +8194,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-x86_64-R4.2.rs
+++ b/bindings/bindings-linux-x86_64-R4.2.rs
@@ -230,11 +230,12 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = __builtin_va_list;
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -252,37 +253,54 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
+    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
+    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
+    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
+    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
+    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
+    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
+    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
+    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -591,21 +609,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -614,7 +638,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -718,6 +744,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -754,6 +781,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -776,6 +804,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -798,6 +827,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -830,6 +860,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -864,6 +895,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -884,8 +916,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
+#[doc = " called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -949,6 +983,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1028,6 +1063,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1050,6 +1086,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1063,7 +1100,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1075,6 +1114,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1102,6 +1142,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1132,9 +1173,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1180,6 +1223,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1223,6 +1267,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1301,6 +1346,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1337,6 +1383,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1349,6 +1396,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1361,6 +1409,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1373,6 +1422,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1381,176 +1431,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1584,6 +1691,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1668,6 +1776,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1787,6 +1896,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1869,6 +1979,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1892,9 +2003,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1919,11 +2032,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1941,6 +2056,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1965,6 +2081,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2035,6 +2152,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2411,6 +2529,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2420,9 +2539,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2444,6 +2565,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2457,6 +2579,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2475,6 +2598,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2490,6 +2614,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2499,6 +2624,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2508,6 +2634,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the public inlinable functions that are provided in\nRinlinedfuns.h It is *essential* that these do not appear in any\nother header file, with or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2754,6 +2881,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2786,6 +2914,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
+#[doc = " try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2817,6 +2946,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
+    #[doc = " public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2860,6 +2990,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
+    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2927,12 +3058,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
+    #[doc = " do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -2960,6 +3094,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2969,15 +3104,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
+    #[doc = " Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2993,6 +3132,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
+    #[doc = " Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3011,27 +3151,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
+    #[doc = " in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
+    #[doc = " in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
+    #[doc = " Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
+#[doc = " = 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
+#[doc = " was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
+#[doc = " Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3257,6 +3404,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3377,6 +3525,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
+    #[doc = " added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3387,6 +3536,7 @@ extern "C" {
     >;
 }
 extern "C" {
+    #[doc = " naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3405,6 +3555,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
+    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3448,12 +3599,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4232,6 +4385,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4598,45 +4752,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4795,47 +4977,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4941,10 +5143,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4965,17 +5169,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4986,7 +5197,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5008,6 +5221,7 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5852,6 +6066,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5901,10 +6116,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5957,6 +6174,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5966,7 +6184,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6007,15 +6227,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
+    #[doc = " Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6207,6 +6437,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -6218,6 +6449,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6377,12 +6609,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6444,6 +6678,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6472,6 +6707,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6483,6 +6719,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6568,6 +6805,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6661,6 +6899,7 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7526,10 +7765,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7567,6 +7808,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7732,6 +7974,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7743,6 +7986,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7751,6 +7995,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7776,6 +8021,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7851,9 +8097,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-x86_64-R4.2.rs
+++ b/bindings/bindings-linux-x86_64-R4.2.rs
@@ -230,12 +230,11 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = __builtin_va_list;
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -253,54 +252,37 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
-    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
-    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
-    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
-    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
-    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
-    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
-    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
-    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
-    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -609,27 +591,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -744,7 +726,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -781,7 +763,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -804,7 +786,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -827,7 +809,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -860,7 +842,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -895,7 +877,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -916,7 +898,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
-#[doc = " called with a variable argument set"]
+#[doc = "called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -1063,7 +1045,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1086,7 +1068,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1100,9 +1082,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1114,7 +1096,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the internal headers"]
+    #[doc = "Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1142,7 +1124,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1173,11 +1155,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1267,7 +1249,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1346,7 +1328,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1383,7 +1365,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1396,7 +1378,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1409,7 +1391,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Promise Access Functions"]
+    #[doc = "Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1422,7 +1404,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " External pointer access macros"]
+    #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1431,233 +1413,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"@\""]
+    #[doc = "\"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1691,7 +1673,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1776,7 +1758,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1896,7 +1878,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1979,7 +1961,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2003,11 +1985,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2032,13 +2014,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2056,7 +2038,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2081,7 +2063,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2152,7 +2134,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2529,7 +2511,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2539,11 +2521,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2565,7 +2547,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2579,7 +2561,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2598,7 +2580,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2614,7 +2596,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2624,7 +2606,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2881,7 +2863,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2914,7 +2896,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
-#[doc = " try to allow some type checking"]
+#[doc = "try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2946,7 +2928,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
-    #[doc = " public C interface"]
+    #[doc = "public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2990,7 +2972,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
-    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
+    #[doc = "stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -3058,15 +3040,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
+    #[doc = "used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " TRUE during interactive use"]
+    #[doc = "TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
-    #[doc = " do not echo R code"]
+    #[doc = "do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3094,7 +3076,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Current image dirty"]
+    #[doc = "Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3104,19 +3086,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
-    #[doc = " Name of the history file"]
+    #[doc = "Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Size of the history file"]
+    #[doc = "Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " restore the history file?"]
+    #[doc = "restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Root of the R tree"]
+    #[doc = "Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3132,7 +3114,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
-    #[doc = " Need opaque pointer type for export"]
+    #[doc = "Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3151,34 +3133,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
-    #[doc = " in ../unix/sys-unix.c"]
+    #[doc = "in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
-    #[doc = " in ../unix/system.c"]
+    #[doc = "in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
-    #[doc = " Initial stack address"]
+    #[doc = "Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
-#[doc = " = 0"]
+#[doc = "= 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
-#[doc = " was === SA_RESTORE"]
+#[doc = "was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
-#[doc = " Startup Actions"]
+#[doc = "Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3404,7 +3386,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
+    #[doc = "New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3525,7 +3507,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
-    #[doc = " added in 3.0.0"]
+    #[doc = "added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3536,7 +3518,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[doc = " naming follows earlier versions in R.app"]
+    #[doc = "naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3555,7 +3537,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
-    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
+    #[doc = "These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3599,14 +3581,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4385,7 +4367,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4752,73 +4734,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4977,67 +4959,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5143,12 +5125,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5169,24 +5151,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5197,9 +5179,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5221,7 +5203,7 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -6066,7 +6048,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6116,12 +6098,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6174,7 +6156,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6184,9 +6166,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6227,25 +6209,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
-    #[doc = " Is a device appending a path ?"]
+    #[doc = "Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6449,7 +6431,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6616,7 +6598,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6678,7 +6660,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6707,7 +6689,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6719,7 +6701,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6805,7 +6787,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6899,7 +6881,7 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7765,12 +7747,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7808,7 +7790,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7974,7 +7956,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7986,7 +7968,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7995,7 +7977,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8021,7 +8003,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8097,11 +8079,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-x86_64-R4.3-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.3-devel.rs
@@ -235,12 +235,11 @@ pub const R_GE_capability_glyphs: u32 = 12;
 pub const R_GE_text_style_normal: u32 = 1;
 pub const R_GE_text_style_italic: u32 = 2;
 pub const R_GE_text_style_oblique: u32 = 3;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = __builtin_va_list;
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -258,54 +257,37 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
-#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
-    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
-    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
-    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
-    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
-    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
-    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
-    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
-    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
-    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
-    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
-    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
-    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -614,27 +596,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -749,7 +731,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -786,7 +768,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -809,7 +791,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -832,7 +814,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -865,7 +847,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -900,7 +882,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -921,7 +903,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
-#[doc = " Called with a variable argument set after casting to a compatible\nfunction pointer."]
+#[doc = "Called with a variable argument set after casting to a compatible\nfunction pointer."]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -1068,7 +1050,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1091,7 +1073,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1105,9 +1087,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1119,7 +1101,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the internal headers"]
+    #[doc = "Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1147,7 +1129,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1178,11 +1160,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1272,7 +1254,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1354,7 +1336,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1391,7 +1373,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1404,7 +1386,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1417,7 +1399,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Promise Access Functions"]
+    #[doc = "Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1430,7 +1412,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " External pointer access macros"]
+    #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1439,233 +1421,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"@\""]
+    #[doc = "\"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1699,7 +1681,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1784,7 +1766,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1904,7 +1886,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1987,7 +1969,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2019,11 +2001,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2048,13 +2030,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2072,7 +2054,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2097,7 +2079,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2168,7 +2150,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2217,7 +2199,7 @@ extern "C" {
     pub fn R_HasFancyBindings(rho: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " ../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
+    #[doc = "../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
     pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
@@ -2546,7 +2528,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2556,11 +2538,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2582,7 +2564,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2596,7 +2578,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2615,7 +2597,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2631,7 +2613,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2641,7 +2623,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2898,7 +2880,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2931,7 +2913,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
-#[doc = " try to allow some type checking"]
+#[doc = "try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2963,7 +2945,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
-    #[doc = " public C interface"]
+    #[doc = "public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -3007,7 +2989,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
-    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
+    #[doc = "stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -3075,15 +3057,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
+    #[doc = "used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " TRUE during interactive use"]
+    #[doc = "TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
-    #[doc = " do not echo R code"]
+    #[doc = "do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3111,7 +3093,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Current image dirty"]
+    #[doc = "Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3121,19 +3103,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
-    #[doc = " Name of the history file"]
+    #[doc = "Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Size of the history file"]
+    #[doc = "Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " restore the history file?"]
+    #[doc = "restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Root of the R tree"]
+    #[doc = "Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3149,7 +3131,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
-    #[doc = " Need opaque pointer type for export"]
+    #[doc = "Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3168,34 +3150,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
-    #[doc = " in ../unix/sys-unix.c"]
+    #[doc = "in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
-    #[doc = " in ../unix/system.c"]
+    #[doc = "in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
-    #[doc = " Initial stack address"]
+    #[doc = "Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
-#[doc = " = 0"]
+#[doc = "= 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
-#[doc = " was === SA_RESTORE"]
+#[doc = "was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
-#[doc = " Startup Actions"]
+#[doc = "Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3421,7 +3403,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
+    #[doc = "New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3542,7 +3524,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
-    #[doc = " added in 3.0.0"]
+    #[doc = "added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3553,7 +3535,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[doc = " naming follows earlier versions in R.app"]
+    #[doc = "naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3572,7 +3554,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
-    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
+    #[doc = "These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3616,14 +3598,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4402,7 +4384,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4769,73 +4751,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4994,67 +4976,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5160,12 +5142,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5186,24 +5168,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5214,9 +5196,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5251,7 +5233,7 @@ pub struct _DevDesc {
             dd: pDevDesc,
         ),
     >,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -6106,7 +6088,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6156,12 +6138,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6214,7 +6196,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6224,9 +6206,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6267,25 +6249,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
-    #[doc = " Is a device appending a path ?"]
+    #[doc = "Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6489,7 +6471,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6656,7 +6638,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6718,7 +6700,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6747,7 +6729,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6759,7 +6741,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6845,7 +6827,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6994,7 +6976,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7952,12 +7934,12 @@ extern "C" {
         arg3: usize,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7995,7 +7977,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8161,7 +8143,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -8173,7 +8155,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8182,7 +8164,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8208,7 +8190,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8284,11 +8266,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-linux-x86_64-R4.3-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.3-devel.rs
@@ -163,8 +163,8 @@ pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
 pub const R_MONTH: &[u8; 3usize] = b"02\0";
-pub const R_DAY: &[u8; 3usize] = b"21\0";
-pub const R_SVN_REVISION: u32 = 83888;
+pub const R_DAY: &[u8; 3usize] = b"26\0";
+pub const R_SVN_REVISION: u32 = 83908;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
@@ -235,11 +235,12 @@ pub const R_GE_capability_glyphs: u32 = 12;
 pub const R_GE_text_style_normal: u32 = 1;
 pub const R_GE_text_style_italic: u32 = 2;
 pub const R_GE_text_style_oblique: u32 = 3;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type va_list = __builtin_va_list;
 pub type __off_t = ::std::os::raw::c_long;
 pub type __off64_t = ::std::os::raw::c_long;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 pub type FILE = _IO_FILE;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -257,37 +258,54 @@ pub struct _IO_wide_data {
     _unused: [u8; 0],
 }
 pub type _IO_lock_t = ::std::os::raw::c_void;
+#[doc = " The tag name of this struct is _IO_FILE to preserve historic\nC++ mangled names for functions taking FILE* arguments.\nThat name should not be used in new code."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _IO_FILE {
+    #[doc = " High-order word is _IO_MAGIC; rest is flags."]
     pub _flags: ::std::os::raw::c_int,
+    #[doc = " Current read pointer"]
     pub _IO_read_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of get area."]
     pub _IO_read_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of putback+get area."]
     pub _IO_read_base: *mut ::std::os::raw::c_char,
+    #[doc = " Start of put area."]
     pub _IO_write_base: *mut ::std::os::raw::c_char,
+    #[doc = " Current put pointer."]
     pub _IO_write_ptr: *mut ::std::os::raw::c_char,
+    #[doc = " End of put area."]
     pub _IO_write_end: *mut ::std::os::raw::c_char,
+    #[doc = " Start of reserve area."]
     pub _IO_buf_base: *mut ::std::os::raw::c_char,
+    #[doc = " End of reserve area."]
     pub _IO_buf_end: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to start of non-current get area."]
     pub _IO_save_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to first valid character of backup area"]
     pub _IO_backup_base: *mut ::std::os::raw::c_char,
+    #[doc = " Pointer to end of non-current get area."]
     pub _IO_save_end: *mut ::std::os::raw::c_char,
     pub _markers: *mut _IO_marker,
     pub _chain: *mut _IO_FILE,
     pub _fileno: ::std::os::raw::c_int,
     pub _flags2: ::std::os::raw::c_int,
+    #[doc = " This used to be _offset but it's too small."]
     pub _old_offset: __off_t,
+    #[doc = " 1+column number of pbase(); 0 is unknown."]
     pub _cur_column: ::std::os::raw::c_ushort,
     pub _vtable_offset: ::std::os::raw::c_schar,
     pub _shortbuf: [::std::os::raw::c_char; 1usize],
     pub _lock: *mut _IO_lock_t,
     pub _offset: __off64_t,
+    #[doc = " Wide character stream stuff."]
     pub _codecvt: *mut _IO_codecvt,
     pub _wide_data: *mut _IO_wide_data,
     pub _freeres_list: *mut _IO_FILE,
     pub _freeres_buf: *mut ::std::os::raw::c_void,
     pub __pad5: usize,
     pub _mode: ::std::os::raw::c_int,
+    #[doc = " Make sure we don't get into trouble again."]
     pub _unused2: [::std::os::raw::c_char; 20usize],
 }
 #[test]
@@ -596,21 +614,27 @@ fn bindgen_test_layout__IO_FILE() {
     );
 }
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -619,7 +643,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -723,6 +749,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -759,6 +786,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -781,6 +809,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -803,6 +832,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -835,6 +865,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -869,6 +900,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -889,8 +921,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
+#[doc = " Called with a variable argument set after casting to a compatible\nfunction pointer."]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -954,6 +988,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1033,6 +1068,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1055,6 +1091,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1068,7 +1105,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1080,6 +1119,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1107,6 +1147,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1137,9 +1178,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1185,6 +1228,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1228,6 +1272,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1309,6 +1354,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1345,6 +1391,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1357,6 +1404,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1369,6 +1417,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1381,6 +1430,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1389,176 +1439,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1592,6 +1699,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1676,6 +1784,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1795,6 +1904,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1877,6 +1987,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1908,9 +2019,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1935,11 +2048,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1957,6 +2072,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1981,6 +2097,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2051,6 +2168,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2099,6 +2217,7 @@ extern "C" {
     pub fn R_HasFancyBindings(rho: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " ../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
     pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
@@ -2427,6 +2546,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2436,9 +2556,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2460,6 +2582,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2473,6 +2596,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2491,6 +2615,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2506,6 +2631,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2515,6 +2641,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2524,6 +2651,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the public inlinable functions that are provided in\nRinlinedfuns.h It is *essential* that these do not appear in any\nother header file, with or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2770,6 +2898,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2802,6 +2931,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
+#[doc = " try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2833,6 +2963,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
+    #[doc = " public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2876,6 +3007,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
+    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2943,12 +3075,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
+    #[doc = " do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -2976,6 +3111,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2985,15 +3121,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
+    #[doc = " Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3009,6 +3149,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
+    #[doc = " Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3027,27 +3168,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
+    #[doc = " in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
+    #[doc = " in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
+    #[doc = " Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
+#[doc = " = 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
+#[doc = " was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
+#[doc = " Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3273,6 +3421,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3393,6 +3542,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
+    #[doc = " added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3403,6 +3553,7 @@ extern "C" {
     >;
 }
 extern "C" {
+    #[doc = " naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3421,6 +3572,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
+    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3464,12 +3616,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4248,6 +4402,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4614,45 +4769,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4811,47 +4994,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4957,10 +5160,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4981,17 +5186,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5002,7 +5214,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5037,6 +5251,7 @@ pub struct _DevDesc {
             dd: pDevDesc,
         ),
     >,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5891,6 +6106,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5940,10 +6156,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5996,6 +6214,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6005,7 +6224,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6046,15 +6267,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
+    #[doc = " Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6246,6 +6477,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -6257,6 +6489,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6416,12 +6649,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6483,6 +6718,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6511,6 +6747,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6522,6 +6759,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6607,6 +6845,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6755,6 +6994,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7712,10 +7952,12 @@ extern "C" {
         arg3: usize,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7753,6 +7995,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7918,6 +8161,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7929,6 +8173,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7937,6 +8182,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7962,6 +8208,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8037,9 +8284,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-macos-aarch64-R4.2.rs
+++ b/bindings/bindings-macos-aarch64-R4.2.rs
@@ -230,14 +230,13 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __int64_t = ::std::os::raw::c_longlong;
 pub type __darwin_va_list = __builtin_va_list;
 pub type __darwin_off_t = __int64_t;
 pub type va_list = __darwin_va_list;
 pub type fpos_t = __darwin_off_t;
-#[doc = " stdio buffers"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sbuf {
@@ -279,31 +278,21 @@ fn bindgen_test_layout___sbuf() {
         )
     );
 }
-#[doc = " hold a buncha junk that would grow the ABI"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILEX {
     _unused: [u8; 0],
 }
-#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILE {
-    #[doc = " current position in (some) buffer"]
     pub _p: *mut ::std::os::raw::c_uchar,
-    #[doc = " read space left for getc()"]
     pub _r: ::std::os::raw::c_int,
-    #[doc = " write space left for putc()"]
     pub _w: ::std::os::raw::c_int,
-    #[doc = " flags, below; this FILE is free if 0"]
     pub _flags: ::std::os::raw::c_short,
-    #[doc = " fileno, if Unix descriptor, else -1"]
     pub _file: ::std::os::raw::c_short,
-    #[doc = " the buffer (at least 1 byte, if !NULL)"]
     pub _bf: __sbuf,
-    #[doc = " 0 or -_bf._size, for inline putc"]
     pub _lbfsize: ::std::os::raw::c_int,
-    #[doc = " cookie passed to io functions"]
     pub _cookie: *mut ::std::os::raw::c_void,
     pub _close: ::std::option::Option<
         unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
@@ -329,21 +318,13 @@ pub struct __sFILE {
             arg3: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
     >,
-    #[doc = " ungetc buffer"]
     pub _ub: __sbuf,
-    #[doc = " additions to FILE to not break ABI"]
     pub _extra: *mut __sFILEX,
-    #[doc = " saved _r when _r is counting ungetc data"]
     pub _ur: ::std::os::raw::c_int,
-    #[doc = " guarantee an ungetc() buffer"]
     pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    #[doc = " guarantee a getc() buffer"]
     pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    #[doc = " buffer for fgetln()"]
     pub _lb: __sbuf,
-    #[doc = " stat.st_blksize (may be != _bf._size)"]
     pub _blksize: ::std::os::raw::c_int,
-    #[doc = " current lseek offset (see WARNING)"]
     pub _offset: fpos_t,
 }
 #[test]
@@ -561,30 +542,29 @@ fn bindgen_test_layout___sFILE() {
         )
     );
 }
-#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 pub type FILE = __sFILE;
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -699,7 +679,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -736,7 +716,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -759,7 +739,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -782,7 +762,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -815,7 +795,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -850,7 +830,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -871,7 +851,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
-#[doc = " called with a variable argument set"]
+#[doc = "called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -1018,7 +998,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1041,7 +1021,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1055,9 +1035,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1069,7 +1049,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the internal headers"]
+    #[doc = "Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1097,7 +1077,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1128,11 +1108,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1222,7 +1202,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1301,7 +1281,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1338,7 +1318,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1351,7 +1331,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1364,7 +1344,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Promise Access Functions"]
+    #[doc = "Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1377,7 +1357,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " External pointer access macros"]
+    #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1386,233 +1366,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"@\""]
+    #[doc = "\"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1646,7 +1626,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1731,7 +1711,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1851,7 +1831,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1934,7 +1914,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1958,11 +1938,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1987,13 +1967,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2011,7 +1991,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2036,7 +2016,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2107,7 +2087,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2484,7 +2464,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2494,11 +2474,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2520,7 +2500,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2534,7 +2514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2553,7 +2533,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2569,7 +2549,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2579,7 +2559,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2836,7 +2816,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2869,7 +2849,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
-#[doc = " try to allow some type checking"]
+#[doc = "try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2901,7 +2881,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
-    #[doc = " public C interface"]
+    #[doc = "public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2945,7 +2925,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
-    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
+    #[doc = "stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -3013,15 +2993,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
+    #[doc = "used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " TRUE during interactive use"]
+    #[doc = "TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
-    #[doc = " do not echo R code"]
+    #[doc = "do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3049,7 +3029,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Current image dirty"]
+    #[doc = "Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3059,19 +3039,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
-    #[doc = " Name of the history file"]
+    #[doc = "Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Size of the history file"]
+    #[doc = "Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " restore the history file?"]
+    #[doc = "restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Root of the R tree"]
+    #[doc = "Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3087,7 +3067,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
-    #[doc = " Need opaque pointer type for export"]
+    #[doc = "Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3106,34 +3086,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
-    #[doc = " in ../unix/sys-unix.c"]
+    #[doc = "in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
-    #[doc = " in ../unix/system.c"]
+    #[doc = "in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
-    #[doc = " Initial stack address"]
+    #[doc = "Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
-#[doc = " = 0"]
+#[doc = "= 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
-#[doc = " was === SA_RESTORE"]
+#[doc = "was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
-#[doc = " Startup Actions"]
+#[doc = "Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3359,7 +3339,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
+    #[doc = "New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3480,7 +3460,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
-    #[doc = " added in 3.0.0"]
+    #[doc = "added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3491,7 +3471,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[doc = " naming follows earlier versions in R.app"]
+    #[doc = "naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3510,7 +3490,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
-    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
+    #[doc = "These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3554,14 +3534,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4340,7 +4320,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4707,73 +4687,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4932,67 +4912,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5098,12 +5078,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5124,24 +5104,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5152,9 +5132,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5176,7 +5156,7 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -6021,7 +6001,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6071,12 +6051,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6129,7 +6109,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6139,9 +6119,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6182,25 +6162,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
-    #[doc = " Is a device appending a path ?"]
+    #[doc = "Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6404,7 +6384,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6571,7 +6551,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6633,7 +6613,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6662,7 +6642,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6674,7 +6654,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6760,7 +6740,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6854,7 +6834,7 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7720,12 +7700,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7763,7 +7743,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7929,7 +7909,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7941,7 +7921,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7950,7 +7930,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7976,7 +7956,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8052,11 +8032,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-macos-aarch64-R4.2.rs
+++ b/bindings/bindings-macos-aarch64-R4.2.rs
@@ -230,13 +230,14 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __int64_t = ::std::os::raw::c_longlong;
 pub type __darwin_va_list = __builtin_va_list;
 pub type __darwin_off_t = __int64_t;
 pub type va_list = __darwin_va_list;
 pub type fpos_t = __darwin_off_t;
+#[doc = " stdio buffers"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sbuf {
@@ -278,21 +279,31 @@ fn bindgen_test_layout___sbuf() {
         )
     );
 }
+#[doc = " hold a buncha junk that would grow the ABI"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILEX {
     _unused: [u8; 0],
 }
+#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILE {
+    #[doc = " current position in (some) buffer"]
     pub _p: *mut ::std::os::raw::c_uchar,
+    #[doc = " read space left for getc()"]
     pub _r: ::std::os::raw::c_int,
+    #[doc = " write space left for putc()"]
     pub _w: ::std::os::raw::c_int,
+    #[doc = " flags, below; this FILE is free if 0"]
     pub _flags: ::std::os::raw::c_short,
+    #[doc = " fileno, if Unix descriptor, else -1"]
     pub _file: ::std::os::raw::c_short,
+    #[doc = " the buffer (at least 1 byte, if !NULL)"]
     pub _bf: __sbuf,
+    #[doc = " 0 or -_bf._size, for inline putc"]
     pub _lbfsize: ::std::os::raw::c_int,
+    #[doc = " cookie passed to io functions"]
     pub _cookie: *mut ::std::os::raw::c_void,
     pub _close: ::std::option::Option<
         unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
@@ -318,13 +329,21 @@ pub struct __sFILE {
             arg3: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
     >,
+    #[doc = " ungetc buffer"]
     pub _ub: __sbuf,
+    #[doc = " additions to FILE to not break ABI"]
     pub _extra: *mut __sFILEX,
+    #[doc = " saved _r when _r is counting ungetc data"]
     pub _ur: ::std::os::raw::c_int,
+    #[doc = " guarantee an ungetc() buffer"]
     pub _ubuf: [::std::os::raw::c_uchar; 3usize],
+    #[doc = " guarantee a getc() buffer"]
     pub _nbuf: [::std::os::raw::c_uchar; 1usize],
+    #[doc = " buffer for fgetln()"]
     pub _lb: __sbuf,
+    #[doc = " stat.st_blksize (may be != _bf._size)"]
     pub _blksize: ::std::os::raw::c_int,
+    #[doc = " current lseek offset (see WARNING)"]
     pub _offset: fpos_t,
 }
 #[test]
@@ -542,23 +561,30 @@ fn bindgen_test_layout___sFILE() {
         )
     );
 }
+#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 pub type FILE = __sFILE;
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -567,7 +593,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -671,6 +699,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -707,6 +736,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -729,6 +759,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -751,6 +782,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -783,6 +815,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -817,6 +850,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -837,8 +871,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
+#[doc = " called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -902,6 +938,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -981,6 +1018,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1003,6 +1041,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1016,7 +1055,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1028,6 +1069,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1055,6 +1097,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1085,9 +1128,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1133,6 +1178,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1176,6 +1222,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1254,6 +1301,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1290,6 +1338,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1302,6 +1351,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1314,6 +1364,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1326,6 +1377,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1334,176 +1386,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1537,6 +1646,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1621,6 +1731,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1740,6 +1851,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1822,6 +1934,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1845,9 +1958,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1872,11 +1987,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1894,6 +2011,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1918,6 +2036,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -1988,6 +2107,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2364,6 +2484,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2373,9 +2494,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2397,6 +2520,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2410,6 +2534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2428,6 +2553,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2443,6 +2569,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2452,6 +2579,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2461,6 +2589,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the public inlinable functions that are provided in\nRinlinedfuns.h It is *essential* that these do not appear in any\nother header file, with or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2707,6 +2836,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2739,6 +2869,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
+#[doc = " try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2770,6 +2901,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
+    #[doc = " public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2813,6 +2945,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
+    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2880,12 +3013,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
+    #[doc = " do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -2913,6 +3049,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2922,15 +3059,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
+    #[doc = " Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2946,6 +3087,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
+    #[doc = " Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -2964,27 +3106,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
+    #[doc = " in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
+    #[doc = " in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
+    #[doc = " Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
+#[doc = " = 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
+#[doc = " was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
+#[doc = " Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3210,6 +3359,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3330,6 +3480,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
+    #[doc = " added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3340,6 +3491,7 @@ extern "C" {
     >;
 }
 extern "C" {
+    #[doc = " naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3358,6 +3510,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
+    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3401,12 +3554,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4185,6 +4340,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4551,45 +4707,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4748,47 +4932,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4894,10 +5098,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4918,17 +5124,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4939,7 +5152,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4961,6 +5176,7 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5805,6 +6021,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5854,10 +6071,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5910,6 +6129,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5919,7 +6139,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5960,15 +6182,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
+    #[doc = " Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6160,6 +6392,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -6171,6 +6404,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6330,12 +6564,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6397,6 +6633,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6425,6 +6662,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6436,6 +6674,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6521,6 +6760,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6614,6 +6854,7 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7479,10 +7720,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7520,6 +7763,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7685,6 +7929,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7696,6 +7941,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7704,6 +7950,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7729,6 +7976,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7804,9 +8052,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-macos-x86_64-R4.1.rs
+++ b/bindings/bindings-macos-x86_64-R4.1.rs
@@ -100,14 +100,13 @@ pub const R_GE_patternExtendRepeat: u32 = 2;
 pub const R_GE_patternExtendReflect: u32 = 3;
 pub const R_GE_patternExtendNone: u32 = 4;
 pub const R_PROBLEM_BUFSIZE: u32 = 4096;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __int64_t = ::std::os::raw::c_longlong;
 pub type __darwin_va_list = __builtin_va_list;
 pub type __darwin_off_t = __int64_t;
 pub type va_list = __darwin_va_list;
 pub type fpos_t = __darwin_off_t;
-#[doc = " stdio buffers"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sbuf {
@@ -149,31 +148,21 @@ fn bindgen_test_layout___sbuf() {
         )
     );
 }
-#[doc = " hold a buncha junk that would grow the ABI"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILEX {
     _unused: [u8; 0],
 }
-#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILE {
-    #[doc = " current position in (some) buffer"]
     pub _p: *mut ::std::os::raw::c_uchar,
-    #[doc = " read space left for getc()"]
     pub _r: ::std::os::raw::c_int,
-    #[doc = " write space left for putc()"]
     pub _w: ::std::os::raw::c_int,
-    #[doc = " flags, below; this FILE is free if 0"]
     pub _flags: ::std::os::raw::c_short,
-    #[doc = " fileno, if Unix descriptor, else -1"]
     pub _file: ::std::os::raw::c_short,
-    #[doc = " the buffer (at least 1 byte, if !NULL)"]
     pub _bf: __sbuf,
-    #[doc = " 0 or -_bf._size, for inline putc"]
     pub _lbfsize: ::std::os::raw::c_int,
-    #[doc = " cookie passed to io functions"]
     pub _cookie: *mut ::std::os::raw::c_void,
     pub _close: ::std::option::Option<
         unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
@@ -199,21 +188,13 @@ pub struct __sFILE {
             arg3: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
     >,
-    #[doc = " ungetc buffer"]
     pub _ub: __sbuf,
-    #[doc = " additions to FILE to not break ABI"]
     pub _extra: *mut __sFILEX,
-    #[doc = " saved _r when _r is counting ungetc data"]
     pub _ur: ::std::os::raw::c_int,
-    #[doc = " guarantee an ungetc() buffer"]
     pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    #[doc = " guarantee a getc() buffer"]
     pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    #[doc = " buffer for fgetln()"]
     pub _lb: __sbuf,
-    #[doc = " stat.st_blksize (may be != _bf._size)"]
     pub _blksize: ::std::os::raw::c_int,
-    #[doc = " current lseek offset (see WARNING)"]
     pub _offset: fpos_t,
 }
 #[test]
@@ -431,30 +412,29 @@ fn bindgen_test_layout___sFILE() {
         )
     );
 }
-#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 pub type FILE = __sFILE;
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -569,7 +549,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -606,7 +586,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -629,7 +609,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -652,7 +632,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -685,7 +665,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -720,7 +700,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -741,7 +721,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
-#[doc = " called with a variable argument set"]
+#[doc = "called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -888,7 +868,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -911,7 +891,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -925,9 +905,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -939,7 +919,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the second USE_RINTERNALS section"]
+    #[doc = "Various tests with macro versions in the second USE_RINTERNALS section"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -967,7 +947,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1046,7 +1026,7 @@ extern "C" {
     pub fn MARK_ASSIGNMENT_CALL(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1056,7 +1036,7 @@ extern "C" {
     pub fn UNSET_S4_OBJECT(x: SEXP);
 }
 extern "C" {
-    #[doc = " JIT optimization support"]
+    #[doc = "JIT optimization support"]
     pub fn NOJIT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1072,14 +1052,14 @@ extern "C" {
     pub fn UNSET_MAYBEJIT(x: SEXP);
 }
 extern "C" {
-    #[doc = " Growable vector support"]
+    #[doc = "Growable vector support"]
     pub fn IS_GROWABLE(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SET_GROWABLE_BIT(x: SEXP);
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1153,7 +1133,7 @@ extern "C" {
     pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn STDVEC_DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -1218,7 +1198,7 @@ extern "C" {
     pub fn ALTVEC_EXTRACT_SUBSET(x: SEXP, indx: SEXP, call: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " data access"]
+    #[doc = "data access"]
     pub fn ALTINTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1280,7 +1260,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1305,7 +1285,7 @@ extern "C" {
     pub fn STRING_NO_NA(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " invoking ALTREP class methods"]
+    #[doc = "invoking ALTREP class methods"]
     pub fn ALTINTEGER_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1353,7 +1333,7 @@ extern "C" {
     pub fn ALTLOGICAL_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
-    #[doc = " constructors for internal ALTREP classes"]
+    #[doc = "constructors for internal ALTREP classes"]
     pub fn R_compact_intrange(n1: R_xlen_t, n2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1472,7 +1452,7 @@ extern "C" {
     pub fn CONS_NR(a: SEXP, b: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1509,7 +1489,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1534,7 +1514,7 @@ extern "C" {
     pub fn SET_INTERNAL(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1559,7 +1539,7 @@ extern "C" {
     pub fn SET_HASHTAB(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Promise Access Functions */\n/* First five have macro versions in Defn.h"]
+    #[doc = "Promise Access Functions */\n/* First five have macro versions in Defn.h"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1584,7 +1564,7 @@ extern "C" {
     pub fn SET_PRCODE(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Hashing Functions */\n/* There are macro versions in Defn.h"]
+    #[doc = "Hashing Functions */\n/* There are macro versions in Defn.h"]
     pub fn HASHASH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1596,229 +1576,229 @@ extern "C" {
 extern "C" {
     pub fn SET_HASHVALUE(x: SEXP, v: ::std::os::raw::c_int);
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1864,7 +1844,7 @@ pub const warn_type_iWARN: warn_type = 1;
 pub const warn_type_iERROR: warn_type = 2;
 pub type warn_type = ::std::os::raw::c_uint;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2002,7 +1982,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2155,7 +2135,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -2286,7 +2266,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2310,11 +2290,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2339,13 +2319,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2363,7 +2343,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2412,7 +2392,7 @@ extern "C" {
     pub fn R_reinit_altrep_classes(arg1: *mut DllInfo);
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2483,7 +2463,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2863,7 +2843,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2873,11 +2853,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2899,7 +2879,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2913,7 +2893,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2932,7 +2912,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2942,14 +2922,14 @@ extern "C" {
     pub fn R_system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
+    #[doc = "R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2959,7 +2939,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -3285,11 +3265,11 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " TRUE during interactive use"]
+    #[doc = "TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
-    #[doc = " do not echo R code"]
+    #[doc = "do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3317,7 +3297,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Current image dirty"]
+    #[doc = "Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3327,19 +3307,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
-    #[doc = " Name of the history file"]
+    #[doc = "Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Size of the history file"]
+    #[doc = "Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " restore the history file?"]
+    #[doc = "restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Root of the R tree"]
+    #[doc = "Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3355,7 +3335,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
-    #[doc = " Need opaque pointer type for export"]
+    #[doc = "Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3374,34 +3354,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
-    #[doc = " in ../unix/sys-unix.c"]
+    #[doc = "in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
-    #[doc = " in ../unix/system.c"]
+    #[doc = "in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
-    #[doc = " Initial stack address"]
+    #[doc = "Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
-#[doc = " = 0"]
+#[doc = "= 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
-#[doc = " was === SA_RESTORE"]
+#[doc = "was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
-#[doc = " Startup Actions"]
+#[doc = "Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3709,7 +3689,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
-    #[doc = " added in 3.0.0"]
+    #[doc = "added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3720,7 +3700,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[doc = " naming follows earlier versions in R.app"]
+    #[doc = "naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3739,7 +3719,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
-    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
+    #[doc = "These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3783,14 +3763,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4560,7 +4540,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4927,73 +4907,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -5152,67 +5132,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5318,12 +5298,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5344,24 +5324,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5372,11 +5352,11 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -6151,7 +6131,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6201,12 +6181,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6259,7 +6239,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6269,9 +6249,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6312,23 +6292,23 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
 }
 #[test]
@@ -6522,7 +6502,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6689,7 +6669,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6751,7 +6731,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6780,7 +6760,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6792,7 +6772,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6878,7 +6858,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6957,7 +6937,7 @@ extern "C" {
     pub fn R_GE_tilingPatternExtend(pattern: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7835,12 +7815,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7878,7 +7858,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8044,7 +8024,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -8056,7 +8036,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8065,7 +8045,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8091,7 +8071,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8167,11 +8147,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-macos-x86_64-R4.1.rs
+++ b/bindings/bindings-macos-x86_64-R4.1.rs
@@ -100,13 +100,14 @@ pub const R_GE_patternExtendRepeat: u32 = 2;
 pub const R_GE_patternExtendReflect: u32 = 3;
 pub const R_GE_patternExtendNone: u32 = 4;
 pub const R_PROBLEM_BUFSIZE: u32 = 4096;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __int64_t = ::std::os::raw::c_longlong;
 pub type __darwin_va_list = __builtin_va_list;
 pub type __darwin_off_t = __int64_t;
 pub type va_list = __darwin_va_list;
 pub type fpos_t = __darwin_off_t;
+#[doc = " stdio buffers"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sbuf {
@@ -148,21 +149,31 @@ fn bindgen_test_layout___sbuf() {
         )
     );
 }
+#[doc = " hold a buncha junk that would grow the ABI"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILEX {
     _unused: [u8; 0],
 }
+#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILE {
+    #[doc = " current position in (some) buffer"]
     pub _p: *mut ::std::os::raw::c_uchar,
+    #[doc = " read space left for getc()"]
     pub _r: ::std::os::raw::c_int,
+    #[doc = " write space left for putc()"]
     pub _w: ::std::os::raw::c_int,
+    #[doc = " flags, below; this FILE is free if 0"]
     pub _flags: ::std::os::raw::c_short,
+    #[doc = " fileno, if Unix descriptor, else -1"]
     pub _file: ::std::os::raw::c_short,
+    #[doc = " the buffer (at least 1 byte, if !NULL)"]
     pub _bf: __sbuf,
+    #[doc = " 0 or -_bf._size, for inline putc"]
     pub _lbfsize: ::std::os::raw::c_int,
+    #[doc = " cookie passed to io functions"]
     pub _cookie: *mut ::std::os::raw::c_void,
     pub _close: ::std::option::Option<
         unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
@@ -188,13 +199,21 @@ pub struct __sFILE {
             arg3: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
     >,
+    #[doc = " ungetc buffer"]
     pub _ub: __sbuf,
+    #[doc = " additions to FILE to not break ABI"]
     pub _extra: *mut __sFILEX,
+    #[doc = " saved _r when _r is counting ungetc data"]
     pub _ur: ::std::os::raw::c_int,
+    #[doc = " guarantee an ungetc() buffer"]
     pub _ubuf: [::std::os::raw::c_uchar; 3usize],
+    #[doc = " guarantee a getc() buffer"]
     pub _nbuf: [::std::os::raw::c_uchar; 1usize],
+    #[doc = " buffer for fgetln()"]
     pub _lb: __sbuf,
+    #[doc = " stat.st_blksize (may be != _bf._size)"]
     pub _blksize: ::std::os::raw::c_int,
+    #[doc = " current lseek offset (see WARNING)"]
     pub _offset: fpos_t,
 }
 #[test]
@@ -412,23 +431,30 @@ fn bindgen_test_layout___sFILE() {
         )
     );
 }
+#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 pub type FILE = __sFILE;
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -437,7 +463,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -541,6 +569,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -577,6 +606,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -599,6 +629,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -621,6 +652,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -653,6 +685,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -687,6 +720,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -707,8 +741,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
+#[doc = " called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -772,6 +808,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -851,6 +888,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -873,6 +911,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -886,7 +925,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -898,6 +939,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the second USE_RINTERNALS section"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -925,6 +967,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1003,6 +1046,7 @@ extern "C" {
     pub fn MARK_ASSIGNMENT_CALL(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1012,6 +1056,7 @@ extern "C" {
     pub fn UNSET_S4_OBJECT(x: SEXP);
 }
 extern "C" {
+    #[doc = " JIT optimization support"]
     pub fn NOJIT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1027,12 +1072,14 @@ extern "C" {
     pub fn UNSET_MAYBEJIT(x: SEXP);
 }
 extern "C" {
+    #[doc = " Growable vector support"]
     pub fn IS_GROWABLE(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SET_GROWABLE_BIT(x: SEXP);
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1087,6 +1134,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1105,6 +1153,7 @@ extern "C" {
     pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn STDVEC_DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -1169,6 +1218,7 @@ extern "C" {
     pub fn ALTVEC_EXTRACT_SUBSET(x: SEXP, indx: SEXP, call: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " data access"]
     pub fn ALTINTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1230,6 +1280,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1254,6 +1305,7 @@ extern "C" {
     pub fn STRING_NO_NA(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " invoking ALTREP class methods"]
     pub fn ALTINTEGER_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1301,6 +1353,7 @@ extern "C" {
     pub fn ALTLOGICAL_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
+    #[doc = " constructors for internal ALTREP classes"]
     pub fn R_compact_intrange(n1: R_xlen_t, n2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1419,6 +1472,7 @@ extern "C" {
     pub fn CONS_NR(a: SEXP, b: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1455,6 +1509,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1479,6 +1534,7 @@ extern "C" {
     pub fn SET_INTERNAL(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1503,6 +1559,7 @@ extern "C" {
     pub fn SET_HASHTAB(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Promise Access Functions */\n/* First five have macro versions in Defn.h"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1527,6 +1584,7 @@ extern "C" {
     pub fn SET_PRCODE(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Hashing Functions */\n/* There are macro versions in Defn.h"]
     pub fn HASHASH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1538,173 +1596,229 @@ extern "C" {
 extern "C" {
     pub fn SET_HASHVALUE(x: SEXP, v: ::std::os::raw::c_int);
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1750,6 +1864,7 @@ pub const warn_type_iWARN: warn_type = 1;
 pub const warn_type_iERROR: warn_type = 2;
 pub type warn_type = ::std::os::raw::c_uint;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1887,6 +2002,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2039,6 +2155,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -2169,6 +2286,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2192,9 +2310,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2219,11 +2339,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2241,6 +2363,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2289,6 +2412,7 @@ extern "C" {
     pub fn R_reinit_altrep_classes(arg1: *mut DllInfo);
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2359,6 +2483,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2738,6 +2863,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2747,9 +2873,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2771,6 +2899,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2784,6 +2913,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2802,6 +2932,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2811,12 +2942,14 @@ extern "C" {
     pub fn R_system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2826,6 +2959,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2835,6 +2969,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the inlinable functions that are provided in Rinlinedfuns.h\nIt is *essential* that these do not appear in any other header file,\nwith or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -3150,9 +3285,11 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
+    #[doc = " do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3180,6 +3317,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3189,15 +3327,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
+    #[doc = " Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3213,6 +3355,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
+    #[doc = " Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3231,27 +3374,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
+    #[doc = " in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
+    #[doc = " in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
+    #[doc = " Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
+#[doc = " = 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
+#[doc = " was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
+#[doc = " Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3559,6 +3709,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
+    #[doc = " added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3569,6 +3720,7 @@ extern "C" {
     >;
 }
 extern "C" {
+    #[doc = " naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3587,6 +3739,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
+    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3630,12 +3783,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4405,6 +4560,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4771,45 +4927,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4968,47 +5152,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5114,10 +5318,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5138,17 +5344,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5159,8 +5372,11 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5935,6 +6151,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5984,10 +6201,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6040,6 +6259,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6049,7 +6269,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6090,14 +6312,23 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
 }
 #[test]
@@ -6279,6 +6510,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -6290,6 +6522,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6449,12 +6682,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6516,6 +6751,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6544,6 +6780,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6555,6 +6792,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6640,6 +6878,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6718,6 +6957,7 @@ extern "C" {
     pub fn R_GE_tilingPatternExtend(pattern: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7595,10 +7835,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7636,6 +7878,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7801,6 +8044,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7812,6 +8056,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7820,6 +8065,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7845,6 +8091,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7920,9 +8167,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-macos-x86_64-R4.2.rs
+++ b/bindings/bindings-macos-x86_64-R4.2.rs
@@ -230,14 +230,13 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __int64_t = ::std::os::raw::c_longlong;
 pub type __darwin_va_list = __builtin_va_list;
 pub type __darwin_off_t = __int64_t;
 pub type va_list = __darwin_va_list;
 pub type fpos_t = __darwin_off_t;
-#[doc = " stdio buffers"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sbuf {
@@ -279,31 +278,21 @@ fn bindgen_test_layout___sbuf() {
         )
     );
 }
-#[doc = " hold a buncha junk that would grow the ABI"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILEX {
     _unused: [u8; 0],
 }
-#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILE {
-    #[doc = " current position in (some) buffer"]
     pub _p: *mut ::std::os::raw::c_uchar,
-    #[doc = " read space left for getc()"]
     pub _r: ::std::os::raw::c_int,
-    #[doc = " write space left for putc()"]
     pub _w: ::std::os::raw::c_int,
-    #[doc = " flags, below; this FILE is free if 0"]
     pub _flags: ::std::os::raw::c_short,
-    #[doc = " fileno, if Unix descriptor, else -1"]
     pub _file: ::std::os::raw::c_short,
-    #[doc = " the buffer (at least 1 byte, if !NULL)"]
     pub _bf: __sbuf,
-    #[doc = " 0 or -_bf._size, for inline putc"]
     pub _lbfsize: ::std::os::raw::c_int,
-    #[doc = " cookie passed to io functions"]
     pub _cookie: *mut ::std::os::raw::c_void,
     pub _close: ::std::option::Option<
         unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
@@ -329,21 +318,13 @@ pub struct __sFILE {
             arg3: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
     >,
-    #[doc = " ungetc buffer"]
     pub _ub: __sbuf,
-    #[doc = " additions to FILE to not break ABI"]
     pub _extra: *mut __sFILEX,
-    #[doc = " saved _r when _r is counting ungetc data"]
     pub _ur: ::std::os::raw::c_int,
-    #[doc = " guarantee an ungetc() buffer"]
     pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    #[doc = " guarantee a getc() buffer"]
     pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    #[doc = " buffer for fgetln()"]
     pub _lb: __sbuf,
-    #[doc = " stat.st_blksize (may be != _bf._size)"]
     pub _blksize: ::std::os::raw::c_int,
-    #[doc = " current lseek offset (see WARNING)"]
     pub _offset: fpos_t,
 }
 #[test]
@@ -561,30 +542,29 @@ fn bindgen_test_layout___sFILE() {
         )
     );
 }
-#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 pub type FILE = __sFILE;
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -699,7 +679,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -736,7 +716,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -759,7 +739,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -782,7 +762,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -815,7 +795,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -850,7 +830,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -871,7 +851,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
-#[doc = " called with a variable argument set"]
+#[doc = "called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -1018,7 +998,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1041,7 +1021,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1055,9 +1035,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1069,7 +1049,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the internal headers"]
+    #[doc = "Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1097,7 +1077,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1128,11 +1108,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1222,7 +1202,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1301,7 +1281,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1338,7 +1318,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1351,7 +1331,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1364,7 +1344,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Promise Access Functions"]
+    #[doc = "Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1377,7 +1357,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " External pointer access macros"]
+    #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1386,233 +1366,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"@\""]
+    #[doc = "\"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1646,7 +1626,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1731,7 +1711,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1851,7 +1831,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1934,7 +1914,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1958,11 +1938,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1987,13 +1967,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2011,7 +1991,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2036,7 +2016,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2107,7 +2087,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2484,7 +2464,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2494,11 +2474,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2520,7 +2500,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2534,7 +2514,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2553,7 +2533,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2569,7 +2549,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2579,7 +2559,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2836,7 +2816,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2869,7 +2849,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
-#[doc = " try to allow some type checking"]
+#[doc = "try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2901,7 +2881,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
-    #[doc = " public C interface"]
+    #[doc = "public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2945,7 +2925,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
-    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
+    #[doc = "stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -3013,15 +2993,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
+    #[doc = "used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " TRUE during interactive use"]
+    #[doc = "TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
-    #[doc = " do not echo R code"]
+    #[doc = "do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3049,7 +3029,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Current image dirty"]
+    #[doc = "Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3059,19 +3039,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
-    #[doc = " Name of the history file"]
+    #[doc = "Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Size of the history file"]
+    #[doc = "Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " restore the history file?"]
+    #[doc = "restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Root of the R tree"]
+    #[doc = "Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3087,7 +3067,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
-    #[doc = " Need opaque pointer type for export"]
+    #[doc = "Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3106,34 +3086,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
-    #[doc = " in ../unix/sys-unix.c"]
+    #[doc = "in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
-    #[doc = " in ../unix/system.c"]
+    #[doc = "in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
-    #[doc = " Initial stack address"]
+    #[doc = "Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
-#[doc = " = 0"]
+#[doc = "= 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
-#[doc = " was === SA_RESTORE"]
+#[doc = "was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
-#[doc = " Startup Actions"]
+#[doc = "Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3359,7 +3339,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
+    #[doc = "New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3480,7 +3460,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
-    #[doc = " added in 3.0.0"]
+    #[doc = "added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3491,7 +3471,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[doc = " naming follows earlier versions in R.app"]
+    #[doc = "naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3510,7 +3490,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
-    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
+    #[doc = "These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3554,14 +3534,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4340,7 +4320,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4707,73 +4687,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4932,67 +4912,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5098,12 +5078,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5124,24 +5104,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5152,9 +5132,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5176,7 +5156,7 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -6021,7 +6001,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6071,12 +6051,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6129,7 +6109,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6139,9 +6119,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6182,25 +6162,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
-    #[doc = " Is a device appending a path ?"]
+    #[doc = "Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6404,7 +6384,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6571,7 +6551,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6633,7 +6613,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6662,7 +6642,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6674,7 +6654,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6760,7 +6740,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6854,7 +6834,7 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7720,12 +7700,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7763,7 +7743,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7929,7 +7909,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7941,7 +7921,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7950,7 +7930,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7976,7 +7956,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8052,11 +8032,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-macos-x86_64-R4.2.rs
+++ b/bindings/bindings-macos-x86_64-R4.2.rs
@@ -230,13 +230,14 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __int64_t = ::std::os::raw::c_longlong;
 pub type __darwin_va_list = __builtin_va_list;
 pub type __darwin_off_t = __int64_t;
 pub type va_list = __darwin_va_list;
 pub type fpos_t = __darwin_off_t;
+#[doc = " stdio buffers"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sbuf {
@@ -278,21 +279,31 @@ fn bindgen_test_layout___sbuf() {
         )
     );
 }
+#[doc = " hold a buncha junk that would grow the ABI"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILEX {
     _unused: [u8; 0],
 }
+#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILE {
+    #[doc = " current position in (some) buffer"]
     pub _p: *mut ::std::os::raw::c_uchar,
+    #[doc = " read space left for getc()"]
     pub _r: ::std::os::raw::c_int,
+    #[doc = " write space left for putc()"]
     pub _w: ::std::os::raw::c_int,
+    #[doc = " flags, below; this FILE is free if 0"]
     pub _flags: ::std::os::raw::c_short,
+    #[doc = " fileno, if Unix descriptor, else -1"]
     pub _file: ::std::os::raw::c_short,
+    #[doc = " the buffer (at least 1 byte, if !NULL)"]
     pub _bf: __sbuf,
+    #[doc = " 0 or -_bf._size, for inline putc"]
     pub _lbfsize: ::std::os::raw::c_int,
+    #[doc = " cookie passed to io functions"]
     pub _cookie: *mut ::std::os::raw::c_void,
     pub _close: ::std::option::Option<
         unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
@@ -318,13 +329,21 @@ pub struct __sFILE {
             arg3: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
     >,
+    #[doc = " ungetc buffer"]
     pub _ub: __sbuf,
+    #[doc = " additions to FILE to not break ABI"]
     pub _extra: *mut __sFILEX,
+    #[doc = " saved _r when _r is counting ungetc data"]
     pub _ur: ::std::os::raw::c_int,
+    #[doc = " guarantee an ungetc() buffer"]
     pub _ubuf: [::std::os::raw::c_uchar; 3usize],
+    #[doc = " guarantee a getc() buffer"]
     pub _nbuf: [::std::os::raw::c_uchar; 1usize],
+    #[doc = " buffer for fgetln()"]
     pub _lb: __sbuf,
+    #[doc = " stat.st_blksize (may be != _bf._size)"]
     pub _blksize: ::std::os::raw::c_int,
+    #[doc = " current lseek offset (see WARNING)"]
     pub _offset: fpos_t,
 }
 #[test]
@@ -542,23 +561,30 @@ fn bindgen_test_layout___sFILE() {
         )
     );
 }
+#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 pub type FILE = __sFILE;
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -567,7 +593,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -671,6 +699,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -707,6 +736,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -729,6 +759,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -751,6 +782,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -783,6 +815,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -817,6 +850,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -837,8 +871,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
+#[doc = " called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -902,6 +938,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -981,6 +1018,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1003,6 +1041,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1016,7 +1055,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1028,6 +1069,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1055,6 +1097,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1085,9 +1128,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1133,6 +1178,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1176,6 +1222,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1254,6 +1301,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1290,6 +1338,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1302,6 +1351,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1314,6 +1364,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1326,6 +1377,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1334,176 +1386,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1537,6 +1646,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1621,6 +1731,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1740,6 +1851,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1822,6 +1934,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1845,9 +1958,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1872,11 +1987,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1894,6 +2011,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1918,6 +2036,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -1988,6 +2107,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2364,6 +2484,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2373,9 +2494,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2397,6 +2520,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2410,6 +2534,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2428,6 +2553,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2443,6 +2569,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2452,6 +2579,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2461,6 +2589,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the public inlinable functions that are provided in\nRinlinedfuns.h It is *essential* that these do not appear in any\nother header file, with or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2707,6 +2836,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2739,6 +2869,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
+#[doc = " try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2770,6 +2901,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
+    #[doc = " public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2813,6 +2945,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
+    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2880,12 +3013,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
+    #[doc = " do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -2913,6 +3049,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2922,15 +3059,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
+    #[doc = " Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2946,6 +3087,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
+    #[doc = " Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -2964,27 +3106,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
+    #[doc = " in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
+    #[doc = " in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
+    #[doc = " Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
+#[doc = " = 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
+#[doc = " was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
+#[doc = " Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3210,6 +3359,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3330,6 +3480,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
+    #[doc = " added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3340,6 +3491,7 @@ extern "C" {
     >;
 }
 extern "C" {
+    #[doc = " naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3358,6 +3510,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
+    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3401,12 +3554,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4185,6 +4340,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4551,45 +4707,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4748,47 +4932,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4894,10 +5098,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4918,17 +5124,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4939,7 +5152,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4961,6 +5176,7 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5805,6 +6021,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5854,10 +6071,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5910,6 +6129,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5919,7 +6139,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5960,15 +6182,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
+    #[doc = " Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6160,6 +6392,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -6171,6 +6404,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6330,12 +6564,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6397,6 +6633,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6425,6 +6662,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6436,6 +6674,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6521,6 +6760,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6614,6 +6854,7 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7479,10 +7720,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7520,6 +7763,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7685,6 +7929,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7696,6 +7941,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7704,6 +7950,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7729,6 +7976,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7804,9 +8052,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-macos-x86_64-R4.3-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.3-devel.rs
@@ -162,13 +162,14 @@ pub const R_MAJOR: &[u8; 2usize] = b"4\0";
 pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
-pub const R_MONTH: &[u8; 3usize] = b"01\0";
-pub const R_DAY: &[u8; 3usize] = b"14\0";
-pub const R_SVN_REVISION: u32 = 83615;
+pub const R_MONTH: &[u8; 3usize] = b"02\0";
+pub const R_DAY: &[u8; 3usize] = b"26\0";
+pub const R_SVN_REVISION: u32 = 83909;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
-pub const R_GE_version: u32 = 15;
+pub const R_GE_glyphs: u32 = 16;
+pub const R_GE_version: u32 = 16;
 pub const MAX_GRAPHICS_SYSTEMS: u32 = 24;
 pub const R_USE_PROTOTYPES: u32 = 1;
 pub const leftButton: u32 = 1;
@@ -230,13 +231,18 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+pub const R_GE_capability_glyphs: u32 = 12;
+pub const R_GE_text_style_normal: u32 = 1;
+pub const R_GE_text_style_italic: u32 = 2;
+pub const R_GE_text_style_oblique: u32 = 3;
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __int64_t = ::std::os::raw::c_longlong;
 pub type __darwin_va_list = __builtin_va_list;
 pub type __darwin_off_t = __int64_t;
 pub type va_list = __darwin_va_list;
 pub type fpos_t = __darwin_off_t;
+#[doc = " stdio buffers"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sbuf {
@@ -278,21 +284,31 @@ fn bindgen_test_layout___sbuf() {
         )
     );
 }
+#[doc = " hold a buncha junk that would grow the ABI"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILEX {
     _unused: [u8; 0],
 }
+#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILE {
+    #[doc = " current position in (some) buffer"]
     pub _p: *mut ::std::os::raw::c_uchar,
+    #[doc = " read space left for getc()"]
     pub _r: ::std::os::raw::c_int,
+    #[doc = " write space left for putc()"]
     pub _w: ::std::os::raw::c_int,
+    #[doc = " flags, below; this FILE is free if 0"]
     pub _flags: ::std::os::raw::c_short,
+    #[doc = " fileno, if Unix descriptor, else -1"]
     pub _file: ::std::os::raw::c_short,
+    #[doc = " the buffer (at least 1 byte, if !NULL)"]
     pub _bf: __sbuf,
+    #[doc = " 0 or -_bf._size, for inline putc"]
     pub _lbfsize: ::std::os::raw::c_int,
+    #[doc = " cookie passed to io functions"]
     pub _cookie: *mut ::std::os::raw::c_void,
     pub _close: ::std::option::Option<
         unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
@@ -318,13 +334,21 @@ pub struct __sFILE {
             arg3: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
     >,
+    #[doc = " ungetc buffer"]
     pub _ub: __sbuf,
+    #[doc = " additions to FILE to not break ABI"]
     pub _extra: *mut __sFILEX,
+    #[doc = " saved _r when _r is counting ungetc data"]
     pub _ur: ::std::os::raw::c_int,
+    #[doc = " guarantee an ungetc() buffer"]
     pub _ubuf: [::std::os::raw::c_uchar; 3usize],
+    #[doc = " guarantee a getc() buffer"]
     pub _nbuf: [::std::os::raw::c_uchar; 1usize],
+    #[doc = " buffer for fgetln()"]
     pub _lb: __sbuf,
+    #[doc = " stat.st_blksize (may be != _bf._size)"]
     pub _blksize: ::std::os::raw::c_int,
+    #[doc = " current lseek offset (see WARNING)"]
     pub _offset: fpos_t,
 }
 #[test]
@@ -542,23 +566,30 @@ fn bindgen_test_layout___sFILE() {
         )
     );
 }
+#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 pub type FILE = __sFILE;
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -567,7 +598,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -671,6 +704,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -707,6 +741,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -729,6 +764,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -751,6 +787,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -783,6 +820,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -817,6 +855,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -837,8 +876,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
+#[doc = " Called with a variable argument set after casting to a compatible\nfunction pointer."]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -902,6 +943,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -981,6 +1023,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1003,6 +1046,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1016,7 +1060,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1028,6 +1074,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1055,6 +1102,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1085,9 +1133,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1133,6 +1183,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1176,6 +1227,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1257,6 +1309,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1293,6 +1346,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1305,6 +1359,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1317,6 +1372,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1329,6 +1385,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1337,176 +1394,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1540,6 +1654,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1624,6 +1739,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1743,6 +1859,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1825,6 +1942,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1856,9 +1974,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1883,11 +2003,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1905,6 +2027,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1929,6 +2052,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -1999,6 +2123,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2047,6 +2172,7 @@ extern "C" {
     pub fn R_HasFancyBindings(rho: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " ../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
     pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
@@ -2375,6 +2501,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2384,9 +2511,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2408,6 +2537,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2421,6 +2551,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2439,6 +2570,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2454,6 +2586,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2463,6 +2596,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2472,6 +2606,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the public inlinable functions that are provided in\nRinlinedfuns.h It is *essential* that these do not appear in any\nother header file, with or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2718,6 +2853,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2750,6 +2886,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
+#[doc = " try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2781,6 +2918,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
+    #[doc = " public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2824,6 +2962,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
+    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2891,12 +3030,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
+    #[doc = " do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -2924,6 +3066,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2933,15 +3076,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
+    #[doc = " Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2957,6 +3104,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
+    #[doc = " Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -2975,27 +3123,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
+    #[doc = " in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
+    #[doc = " in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
+    #[doc = " Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
+#[doc = " = 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
+#[doc = " was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
+#[doc = " Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3221,6 +3376,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3341,6 +3497,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
+    #[doc = " added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3351,6 +3508,7 @@ extern "C" {
     >;
 }
 extern "C" {
+    #[doc = " naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3369,6 +3527,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
+    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3412,12 +3571,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4196,6 +4357,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4562,45 +4724,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4759,47 +4949,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4905,10 +5115,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4929,17 +5141,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4950,7 +5169,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4972,6 +5193,20 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
+    pub glyph: ::std::option::Option<
+        unsafe extern "C" fn(
+            n: ::std::os::raw::c_int,
+            glyphs: *mut ::std::os::raw::c_int,
+            x: *mut f64,
+            y: *mut f64,
+            font: SEXP,
+            size: f64,
+            colour: ::std::os::raw::c_int,
+            rot: f64,
+            dd: pDevDesc,
+        ),
+    >,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -4980,7 +5215,7 @@ fn bindgen_test_layout__DevDesc() {
     let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<_DevDesc>(),
-        648usize,
+        656usize,
         concat!("Size of: ", stringify!(_DevDesc))
     );
     assert_eq!(
@@ -5799,8 +6034,18 @@ fn bindgen_test_layout__DevDesc() {
         )
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).reserved) as usize - ptr as usize },
+        unsafe { ::std::ptr::addr_of!((*ptr).glyph) as usize - ptr as usize },
         584usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_DevDesc),
+            "::",
+            stringify!(glyph)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).reserved) as usize - ptr as usize },
+        592usize,
         concat!(
             "Offset of field: ",
             stringify!(_DevDesc),
@@ -5816,6 +6061,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5865,10 +6111,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5921,6 +6169,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5930,7 +6179,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5971,15 +6222,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
+    #[doc = " Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6171,6 +6432,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -6182,6 +6444,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6341,12 +6604,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6408,6 +6673,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6436,6 +6702,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6447,6 +6714,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6532,6 +6800,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6625,6 +6894,62 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    pub fn R_GE_glyphInfoGlyphs(glyphInfo: SEXP) -> SEXP;
+}
+extern "C" {
+    pub fn R_GE_glyphInfoFonts(glyphInfo: SEXP) -> SEXP;
+}
+extern "C" {
+    pub fn R_GE_glyphID(glyphs: SEXP) -> SEXP;
+}
+extern "C" {
+    pub fn R_GE_glyphX(glyphs: SEXP) -> SEXP;
+}
+extern "C" {
+    pub fn R_GE_glyphY(glyphs: SEXP) -> SEXP;
+}
+extern "C" {
+    pub fn R_GE_glyphFont(glyphs: SEXP) -> SEXP;
+}
+extern "C" {
+    pub fn R_GE_glyphSize(glyphs: SEXP) -> SEXP;
+}
+extern "C" {
+    pub fn R_GE_glyphColour(glyphs: SEXP) -> SEXP;
+}
+extern "C" {
+    pub fn R_GE_glyphFontFile(glyphFont: SEXP) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn R_GE_glyphFontIndex(glyphFont: SEXP) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn R_GE_glyphFontFamily(glyphFont: SEXP) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn R_GE_glyphFontWeight(glyphFont: SEXP) -> f64;
+}
+extern "C" {
+    pub fn R_GE_glyphFontStyle(glyphFont: SEXP) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn R_GE_glyphFontPSname(glyphFont: SEXP) -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn GEGlyph(
+        n: ::std::os::raw::c_int,
+        glyphs: *mut ::std::os::raw::c_int,
+        x: *mut f64,
+        y: *mut f64,
+        font: SEXP,
+        size: f64,
+        colour: ::std::os::raw::c_int,
+        rot: f64,
+        dd: pGEDevDesc,
+    );
+}
+extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7582,10 +7907,12 @@ extern "C" {
         arg3: usize,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7623,6 +7950,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7788,6 +8116,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7799,6 +8128,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7807,6 +8137,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7832,6 +8163,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7907,9 +8239,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-macos-x86_64-R4.3-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.3-devel.rs
@@ -163,8 +163,8 @@ pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
 pub const R_MONTH: &[u8; 3usize] = b"02\0";
-pub const R_DAY: &[u8; 3usize] = b"26\0";
-pub const R_SVN_REVISION: u32 = 83909;
+pub const R_DAY: &[u8; 3usize] = b"27\0";
+pub const R_SVN_REVISION: u32 = 83911;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
@@ -235,14 +235,13 @@ pub const R_GE_capability_glyphs: u32 = 12;
 pub const R_GE_text_style_normal: u32 = 1;
 pub const R_GE_text_style_italic: u32 = 2;
 pub const R_GE_text_style_oblique: u32 = 3;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __int64_t = ::std::os::raw::c_longlong;
 pub type __darwin_va_list = __builtin_va_list;
 pub type __darwin_off_t = __int64_t;
 pub type va_list = __darwin_va_list;
 pub type fpos_t = __darwin_off_t;
-#[doc = " stdio buffers"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sbuf {
@@ -284,31 +283,21 @@ fn bindgen_test_layout___sbuf() {
         )
     );
 }
-#[doc = " hold a buncha junk that would grow the ABI"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILEX {
     _unused: [u8; 0],
 }
-#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct __sFILE {
-    #[doc = " current position in (some) buffer"]
     pub _p: *mut ::std::os::raw::c_uchar,
-    #[doc = " read space left for getc()"]
     pub _r: ::std::os::raw::c_int,
-    #[doc = " write space left for putc()"]
     pub _w: ::std::os::raw::c_int,
-    #[doc = " flags, below; this FILE is free if 0"]
     pub _flags: ::std::os::raw::c_short,
-    #[doc = " fileno, if Unix descriptor, else -1"]
     pub _file: ::std::os::raw::c_short,
-    #[doc = " the buffer (at least 1 byte, if !NULL)"]
     pub _bf: __sbuf,
-    #[doc = " 0 or -_bf._size, for inline putc"]
     pub _lbfsize: ::std::os::raw::c_int,
-    #[doc = " cookie passed to io functions"]
     pub _cookie: *mut ::std::os::raw::c_void,
     pub _close: ::std::option::Option<
         unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
@@ -334,21 +323,13 @@ pub struct __sFILE {
             arg3: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
     >,
-    #[doc = " ungetc buffer"]
     pub _ub: __sbuf,
-    #[doc = " additions to FILE to not break ABI"]
     pub _extra: *mut __sFILEX,
-    #[doc = " saved _r when _r is counting ungetc data"]
     pub _ur: ::std::os::raw::c_int,
-    #[doc = " guarantee an ungetc() buffer"]
     pub _ubuf: [::std::os::raw::c_uchar; 3usize],
-    #[doc = " guarantee a getc() buffer"]
     pub _nbuf: [::std::os::raw::c_uchar; 1usize],
-    #[doc = " buffer for fgetln()"]
     pub _lb: __sbuf,
-    #[doc = " stat.st_blksize (may be != _bf._size)"]
     pub _blksize: ::std::os::raw::c_int,
-    #[doc = " current lseek offset (see WARNING)"]
     pub _offset: fpos_t,
 }
 #[test]
@@ -566,30 +547,29 @@ fn bindgen_test_layout___sFILE() {
         )
     );
 }
-#[doc = " stdio state variables.\n\n The following always hold:\n\n\tif (_flags&(__SLBF|__SWR)) == (__SLBF|__SWR),\n\t\t_lbfsize is -_bf._size, else _lbfsize is 0\n\tif _flags&__SRD, _w is 0\n\tif _flags&__SWR, _r is 0\n\n This ensures that the getc and putc macros (or inline functions) never\n try to write or read from a file that is in `read' or `write' mode.\n (Moreover, they can, and do, automatically switch from read mode to\n write mode, and back, on \"r+\" and \"w+\" files.)\n\n _lbfsize is used only to make the inline line-buffered output stream\n code as compact as possible.\n\n _ub, _up, and _ur are used when ungetc() pushes back more characters\n than fit in the current _bf, or when ungetc() pushes back a character\n that does not match the previous one in _bf.  When this happens,\n _ub._base becomes non-nil (i.e., a stream has ungetc() data iff\n _ub._base!=NULL) and _up and _ur save the current values of _p and _r.\n\n NB: see WARNING above before changing the layout of this structure!"]
 pub type FILE = __sFILE;
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -704,7 +684,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -741,7 +721,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -764,7 +744,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -787,7 +767,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -820,7 +800,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -855,7 +835,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -876,7 +856,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: *mut __va_list_tag);
 }
-#[doc = " Called with a variable argument set after casting to a compatible\nfunction pointer."]
+#[doc = "Called with a variable argument set after casting to a compatible\nfunction pointer."]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -1023,7 +1003,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -1046,7 +1026,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -1060,9 +1040,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1074,7 +1054,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the internal headers"]
+    #[doc = "Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -1102,7 +1082,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1133,11 +1113,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1227,7 +1207,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1309,7 +1289,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1346,7 +1326,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1359,7 +1339,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1372,7 +1352,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Promise Access Functions"]
+    #[doc = "Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1385,7 +1365,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " External pointer access macros"]
+    #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1394,233 +1374,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"@\""]
+    #[doc = "\"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1654,7 +1634,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1739,7 +1719,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1859,7 +1839,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1942,7 +1922,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1974,11 +1954,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2003,13 +1983,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2027,7 +2007,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2052,7 +2032,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2123,7 +2103,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2172,7 +2152,7 @@ extern "C" {
     pub fn R_HasFancyBindings(rho: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " ../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
+    #[doc = "../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
     pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
@@ -2501,7 +2481,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2511,11 +2491,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2537,7 +2517,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2551,7 +2531,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2570,7 +2550,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2586,7 +2566,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2596,7 +2576,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2853,7 +2833,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2886,7 +2866,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
-#[doc = " try to allow some type checking"]
+#[doc = "try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2918,7 +2898,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
-    #[doc = " public C interface"]
+    #[doc = "public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2962,7 +2942,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
-    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
+    #[doc = "stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -3030,15 +3010,15 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
+    #[doc = "used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " TRUE during interactive use"]
+    #[doc = "TRUE during interactive use"]
     pub static mut R_Interactive: Rboolean;
 }
 extern "C" {
-    #[doc = " do not echo R code"]
+    #[doc = "do not echo R code"]
     pub static mut R_NoEcho: Rboolean;
 }
 extern "C" {
@@ -3066,7 +3046,7 @@ extern "C" {
     pub fn R_HomeDir() -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Current image dirty"]
+    #[doc = "Current image dirty"]
     pub static mut R_DirtyImage: ::std::os::raw::c_int;
 }
 extern "C" {
@@ -3076,19 +3056,19 @@ extern "C" {
     pub fn R_setupHistory();
 }
 extern "C" {
-    #[doc = " Name of the history file"]
+    #[doc = "Name of the history file"]
     pub static mut R_HistoryFile: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Size of the history file"]
+    #[doc = "Size of the history file"]
     pub static mut R_HistorySize: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " restore the history file?"]
+    #[doc = "restore the history file?"]
     pub static mut R_RestoreHistory: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Root of the R tree"]
+    #[doc = "Root of the R tree"]
     pub static mut R_Home: *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -3104,7 +3084,7 @@ extern "C" {
     pub fn Rf_onintrNoResume();
 }
 extern "C" {
-    #[doc = " Need opaque pointer type for export"]
+    #[doc = "Need opaque pointer type for export"]
     pub static mut R_GlobalContext: *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -3123,34 +3103,34 @@ extern "C" {
     pub static mut R_Outputfile: *mut FILE;
 }
 extern "C" {
-    #[doc = " in ../unix/sys-unix.c"]
+    #[doc = "in ../unix/sys-unix.c"]
     pub fn R_setStartTime();
 }
 extern "C" {
     pub fn fpu_setup(arg1: Rboolean);
 }
 extern "C" {
-    #[doc = " in ../unix/system.c"]
+    #[doc = "in ../unix/system.c"]
     pub static mut R_running_as_main_program: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
-    #[doc = " Initial stack address"]
+    #[doc = "Initial stack address"]
     pub static mut R_CStackStart: usize;
 }
-#[doc = " = 0"]
+#[doc = "= 0"]
 pub const SA_TYPE_SA_NORESTORE: SA_TYPE = 0;
 pub const SA_TYPE_SA_RESTORE: SA_TYPE = 1;
-#[doc = " was === SA_RESTORE"]
+#[doc = "was === SA_RESTORE"]
 pub const SA_TYPE_SA_DEFAULT: SA_TYPE = 2;
 pub const SA_TYPE_SA_NOSAVE: SA_TYPE = 3;
 pub const SA_TYPE_SA_SAVE: SA_TYPE = 4;
 pub const SA_TYPE_SA_SAVEASK: SA_TYPE = 5;
 pub const SA_TYPE_SA_SUICIDE: SA_TYPE = 6;
-#[doc = " Startup Actions"]
+#[doc = "Startup Actions"]
 pub type SA_TYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -3376,7 +3356,7 @@ extern "C" {
     pub fn R_DefParamsEx(arg1: Rstart, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
+    #[doc = "New code should always use R_DefParamsEx(Rstart, RSTART_VERSION) to\ninform R about the version of the structure used. R_DefParams(Rstart)\nonly supports version 0 of the structure."]
     pub fn R_SetParams(arg1: Rstart);
 }
 extern "C" {
@@ -3497,7 +3477,7 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP)>;
 }
 extern "C" {
-    #[doc = " added in 3.0.0"]
+    #[doc = "added in 3.0.0"]
     pub static mut ptr_R_EditFiles: ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_int,
@@ -3508,7 +3488,7 @@ extern "C" {
     >;
 }
 extern "C" {
-    #[doc = " naming follows earlier versions in R.app"]
+    #[doc = "naming follows earlier versions in R.app"]
     pub static mut ptr_do_selectlist: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: SEXP, arg3: SEXP, arg4: SEXP) -> SEXP,
     >;
@@ -3527,7 +3507,7 @@ extern "C" {
     pub static mut ptr_R_ProcessEvents: ::std::option::Option<unsafe extern "C" fn()>;
 }
 extern "C" {
-    #[doc = " These two are not used by R itself, but are used by the tcltk package"]
+    #[doc = "These two are not used by R itself, but are used by the tcltk package"]
     pub static mut R_timeout_handler:
         ::std::option::Option<unsafe extern "C" fn() -> ::std::os::raw::c_int>;
 }
@@ -3571,14 +3551,14 @@ extern "C" {
     pub static mut R_TempDir: *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -4357,7 +4337,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4724,73 +4704,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4949,67 +4929,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -5115,12 +5095,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5141,24 +5121,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -5169,9 +5149,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -5206,7 +5186,7 @@ pub struct _DevDesc {
             dd: pDevDesc,
         ),
     >,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -6061,7 +6041,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -6111,12 +6091,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -6169,7 +6149,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -6179,9 +6159,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -6222,25 +6202,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
-    #[doc = " Is a device appending a path ?"]
+    #[doc = "Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -6444,7 +6424,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6611,7 +6591,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6673,7 +6653,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6702,7 +6682,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6714,7 +6694,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6800,7 +6780,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6949,7 +6929,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7907,12 +7887,12 @@ extern "C" {
         arg3: usize,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7950,7 +7930,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8116,7 +8096,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -8128,7 +8108,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8137,7 +8117,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -8163,7 +8143,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -8239,11 +8219,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-windows-x86-R4.1.rs
+++ b/bindings/bindings-windows-x86-R4.1.rs
@@ -99,7 +99,7 @@ pub const R_GE_patternExtendRepeat: u32 = 2;
 pub const R_GE_patternExtendReflect: u32 = 3;
 pub const R_GE_patternExtendNone: u32 = 4;
 pub const R_PROBLEM_BUFSIZE: u32 = 4096;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __gnuc_va_list;
@@ -212,21 +212,27 @@ fn bindgen_test_layout__iobuf() {
 }
 pub type FILE = _iobuf;
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -235,7 +241,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -339,6 +347,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -375,6 +384,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -397,6 +407,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -419,6 +430,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -451,6 +463,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -485,6 +498,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -505,8 +519,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
+#[doc = " called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -570,6 +586,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -649,6 +666,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -671,6 +689,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -684,7 +703,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -696,6 +717,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the second USE_RINTERNALS section"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -723,6 +745,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -801,6 +824,7 @@ extern "C" {
     pub fn MARK_ASSIGNMENT_CALL(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -810,6 +834,7 @@ extern "C" {
     pub fn UNSET_S4_OBJECT(x: SEXP);
 }
 extern "C" {
+    #[doc = " JIT optimization support"]
     pub fn NOJIT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -825,12 +850,14 @@ extern "C" {
     pub fn UNSET_MAYBEJIT(x: SEXP);
 }
 extern "C" {
+    #[doc = " Growable vector support"]
     pub fn IS_GROWABLE(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SET_GROWABLE_BIT(x: SEXP);
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -885,6 +912,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -903,6 +931,7 @@ extern "C" {
     pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn STDVEC_DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -967,6 +996,7 @@ extern "C" {
     pub fn ALTVEC_EXTRACT_SUBSET(x: SEXP, indx: SEXP, call: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " data access"]
     pub fn ALTINTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1028,6 +1058,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1052,6 +1083,7 @@ extern "C" {
     pub fn STRING_NO_NA(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " invoking ALTREP class methods"]
     pub fn ALTINTEGER_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1099,6 +1131,7 @@ extern "C" {
     pub fn ALTLOGICAL_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
+    #[doc = " constructors for internal ALTREP classes"]
     pub fn R_compact_intrange(n1: R_xlen_t, n2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1210,6 +1243,7 @@ extern "C" {
     pub fn CONS_NR(a: SEXP, b: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1246,6 +1280,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1270,6 +1305,7 @@ extern "C" {
     pub fn SET_INTERNAL(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1294,6 +1330,7 @@ extern "C" {
     pub fn SET_HASHTAB(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Promise Access Functions */\n/* First five have macro versions in Defn.h"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1318,6 +1355,7 @@ extern "C" {
     pub fn SET_PRCODE(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Hashing Functions */\n/* There are macro versions in Defn.h"]
     pub fn HASHASH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1329,173 +1367,229 @@ extern "C" {
 extern "C" {
     pub fn SET_HASHVALUE(x: SEXP, v: ::std::os::raw::c_int);
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1541,6 +1635,7 @@ pub const warn_type_iWARN: warn_type = 1;
 pub const warn_type_iERROR: warn_type = 2;
 pub type warn_type = ::std::os::raw::c_uint;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1678,6 +1773,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1830,6 +1926,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1960,6 +2057,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1983,9 +2081,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2010,11 +2110,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2032,6 +2134,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2080,6 +2183,7 @@ extern "C" {
     pub fn R_reinit_altrep_classes(arg1: *mut DllInfo);
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2150,6 +2254,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2529,6 +2634,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2538,9 +2644,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2562,6 +2670,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2575,6 +2684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2593,6 +2703,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2602,12 +2713,14 @@ extern "C" {
     pub fn R_system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2617,6 +2730,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2626,6 +2740,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the inlinable functions that are provided in Rinlinedfuns.h\nIt is *essential* that these do not appear in any other header file,\nwith or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2941,6 +3056,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
@@ -3022,12 +3138,14 @@ extern "C" {
     pub fn readconsolecfg();
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -3797,6 +3915,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4163,45 +4282,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4360,47 +4507,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4506,10 +4673,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4530,17 +4699,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4551,8 +4727,11 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5327,6 +5506,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5376,10 +5556,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5435,6 +5617,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5444,7 +5627,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5485,14 +5670,23 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
 }
 #[test]
@@ -5674,6 +5868,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -5685,6 +5880,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -5844,12 +6040,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -5911,6 +6109,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -5939,6 +6138,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -5950,6 +6150,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6035,6 +6236,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6113,6 +6315,7 @@ extern "C" {
     pub fn R_GE_tilingPatternExtend(pattern: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -6990,10 +7193,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7031,6 +7236,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7196,6 +7402,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7207,6 +7414,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7215,6 +7423,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7240,6 +7449,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7315,9 +7525,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-windows-x86-R4.1.rs
+++ b/bindings/bindings-windows-x86-R4.1.rs
@@ -99,7 +99,7 @@ pub const R_GE_patternExtendRepeat: u32 = 2;
 pub const R_GE_patternExtendReflect: u32 = 3;
 pub const R_GE_patternExtendNone: u32 = 4;
 pub const R_PROBLEM_BUFSIZE: u32 = 4096;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __gnuc_va_list;
@@ -212,27 +212,27 @@ fn bindgen_test_layout__iobuf() {
 }
 pub type FILE = _iobuf;
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -347,7 +347,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -384,7 +384,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -407,7 +407,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -430,7 +430,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -463,7 +463,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -498,7 +498,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -519,7 +519,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
-#[doc = " called with a variable argument set"]
+#[doc = "called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -666,7 +666,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -689,7 +689,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -703,9 +703,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -717,7 +717,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the second USE_RINTERNALS section"]
+    #[doc = "Various tests with macro versions in the second USE_RINTERNALS section"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -745,7 +745,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -824,7 +824,7 @@ extern "C" {
     pub fn MARK_ASSIGNMENT_CALL(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -834,7 +834,7 @@ extern "C" {
     pub fn UNSET_S4_OBJECT(x: SEXP);
 }
 extern "C" {
-    #[doc = " JIT optimization support"]
+    #[doc = "JIT optimization support"]
     pub fn NOJIT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -850,14 +850,14 @@ extern "C" {
     pub fn UNSET_MAYBEJIT(x: SEXP);
 }
 extern "C" {
-    #[doc = " Growable vector support"]
+    #[doc = "Growable vector support"]
     pub fn IS_GROWABLE(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SET_GROWABLE_BIT(x: SEXP);
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -931,7 +931,7 @@ extern "C" {
     pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn STDVEC_DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -996,7 +996,7 @@ extern "C" {
     pub fn ALTVEC_EXTRACT_SUBSET(x: SEXP, indx: SEXP, call: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " data access"]
+    #[doc = "data access"]
     pub fn ALTINTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1058,7 +1058,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1083,7 +1083,7 @@ extern "C" {
     pub fn STRING_NO_NA(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " invoking ALTREP class methods"]
+    #[doc = "invoking ALTREP class methods"]
     pub fn ALTINTEGER_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1131,7 +1131,7 @@ extern "C" {
     pub fn ALTLOGICAL_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
-    #[doc = " constructors for internal ALTREP classes"]
+    #[doc = "constructors for internal ALTREP classes"]
     pub fn R_compact_intrange(n1: R_xlen_t, n2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1243,7 +1243,7 @@ extern "C" {
     pub fn CONS_NR(a: SEXP, b: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1280,7 +1280,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1305,7 +1305,7 @@ extern "C" {
     pub fn SET_INTERNAL(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1330,7 +1330,7 @@ extern "C" {
     pub fn SET_HASHTAB(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Promise Access Functions */\n/* First five have macro versions in Defn.h"]
+    #[doc = "Promise Access Functions */\n/* First five have macro versions in Defn.h"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1355,7 +1355,7 @@ extern "C" {
     pub fn SET_PRCODE(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Hashing Functions */\n/* There are macro versions in Defn.h"]
+    #[doc = "Hashing Functions */\n/* There are macro versions in Defn.h"]
     pub fn HASHASH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1367,229 +1367,229 @@ extern "C" {
 extern "C" {
     pub fn SET_HASHVALUE(x: SEXP, v: ::std::os::raw::c_int);
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1635,7 +1635,7 @@ pub const warn_type_iWARN: warn_type = 1;
 pub const warn_type_iERROR: warn_type = 2;
 pub type warn_type = ::std::os::raw::c_uint;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1773,7 +1773,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1926,7 +1926,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -2057,7 +2057,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2081,11 +2081,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2110,13 +2110,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2134,7 +2134,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2183,7 +2183,7 @@ extern "C" {
     pub fn R_reinit_altrep_classes(arg1: *mut DllInfo);
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2254,7 +2254,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2634,7 +2634,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2644,11 +2644,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2670,7 +2670,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2684,7 +2684,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2703,7 +2703,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2713,14 +2713,14 @@ extern "C" {
     pub fn R_system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
+    #[doc = "R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2730,7 +2730,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -3056,7 +3056,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
@@ -3138,14 +3138,14 @@ extern "C" {
     pub fn readconsolecfg();
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -3915,7 +3915,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4282,73 +4282,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4507,67 +4507,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4673,12 +4673,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4699,24 +4699,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4727,11 +4727,11 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5506,7 +5506,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5556,12 +5556,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5617,7 +5617,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5627,9 +5627,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5670,23 +5670,23 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
 }
 #[test]
@@ -5880,7 +5880,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6047,7 +6047,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6109,7 +6109,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6138,7 +6138,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6150,7 +6150,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6236,7 +6236,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6315,7 +6315,7 @@ extern "C" {
     pub fn R_GE_tilingPatternExtend(pattern: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7193,12 +7193,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7236,7 +7236,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7402,7 +7402,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7414,7 +7414,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7423,7 +7423,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7449,7 +7449,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7525,11 +7525,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-windows-x86_64-R4.1.rs
+++ b/bindings/bindings-windows-x86_64-R4.1.rs
@@ -100,7 +100,7 @@ pub const R_GE_patternExtendRepeat: u32 = 2;
 pub const R_GE_patternExtendReflect: u32 = 3;
 pub const R_GE_patternExtendNone: u32 = 4;
 pub const R_PROBLEM_BUFSIZE: u32 = 4096;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __gnuc_va_list;
@@ -213,21 +213,27 @@ fn bindgen_test_layout__iobuf() {
 }
 pub type FILE = _iobuf;
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -236,7 +242,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -340,6 +348,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -376,6 +385,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -398,6 +408,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -420,6 +431,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -452,6 +464,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -486,6 +499,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -506,8 +520,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
+#[doc = " called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -571,6 +587,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -650,6 +667,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -672,6 +690,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -685,7 +704,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -697,6 +718,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the second USE_RINTERNALS section"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -724,6 +746,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -802,6 +825,7 @@ extern "C" {
     pub fn MARK_ASSIGNMENT_CALL(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -811,6 +835,7 @@ extern "C" {
     pub fn UNSET_S4_OBJECT(x: SEXP);
 }
 extern "C" {
+    #[doc = " JIT optimization support"]
     pub fn NOJIT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -826,12 +851,14 @@ extern "C" {
     pub fn UNSET_MAYBEJIT(x: SEXP);
 }
 extern "C" {
+    #[doc = " Growable vector support"]
     pub fn IS_GROWABLE(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SET_GROWABLE_BIT(x: SEXP);
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -886,6 +913,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -904,6 +932,7 @@ extern "C" {
     pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn STDVEC_DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -968,6 +997,7 @@ extern "C" {
     pub fn ALTVEC_EXTRACT_SUBSET(x: SEXP, indx: SEXP, call: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " data access"]
     pub fn ALTINTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1029,6 +1059,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1053,6 +1084,7 @@ extern "C" {
     pub fn STRING_NO_NA(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " invoking ALTREP class methods"]
     pub fn ALTINTEGER_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1100,6 +1132,7 @@ extern "C" {
     pub fn ALTLOGICAL_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
+    #[doc = " constructors for internal ALTREP classes"]
     pub fn R_compact_intrange(n1: R_xlen_t, n2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1218,6 +1251,7 @@ extern "C" {
     pub fn CONS_NR(a: SEXP, b: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1254,6 +1288,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1278,6 +1313,7 @@ extern "C" {
     pub fn SET_INTERNAL(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1302,6 +1338,7 @@ extern "C" {
     pub fn SET_HASHTAB(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Promise Access Functions */\n/* First five have macro versions in Defn.h"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1326,6 +1363,7 @@ extern "C" {
     pub fn SET_PRCODE(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Hashing Functions */\n/* There are macro versions in Defn.h"]
     pub fn HASHASH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1337,173 +1375,229 @@ extern "C" {
 extern "C" {
     pub fn SET_HASHVALUE(x: SEXP, v: ::std::os::raw::c_int);
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1549,6 +1643,7 @@ pub const warn_type_iWARN: warn_type = 1;
 pub const warn_type_iERROR: warn_type = 2;
 pub type warn_type = ::std::os::raw::c_uint;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1686,6 +1781,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1838,6 +1934,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1968,6 +2065,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1991,9 +2089,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2018,11 +2118,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2040,6 +2142,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2088,6 +2191,7 @@ extern "C" {
     pub fn R_reinit_altrep_classes(arg1: *mut DllInfo);
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2158,6 +2262,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2537,6 +2642,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2546,9 +2652,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2570,6 +2678,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2583,6 +2692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2601,6 +2711,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2610,12 +2721,14 @@ extern "C" {
     pub fn R_system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2625,6 +2738,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2634,6 +2748,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the inlinable functions that are provided in Rinlinedfuns.h\nIt is *essential* that these do not appear in any other header file,\nwith or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2949,6 +3064,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
@@ -3030,12 +3146,14 @@ extern "C" {
     pub fn readconsolecfg();
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -3805,6 +3923,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4171,45 +4290,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4368,47 +4515,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4514,10 +4681,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4538,17 +4707,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4559,8 +4735,11 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5335,6 +5514,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5384,10 +5564,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5443,6 +5625,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5452,7 +5635,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5493,14 +5678,23 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
 }
 #[test]
@@ -5682,6 +5876,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -5693,6 +5888,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -5852,12 +6048,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -5919,6 +6117,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -5947,6 +6146,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -5958,6 +6158,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6043,6 +6244,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6121,6 +6323,7 @@ extern "C" {
     pub fn R_GE_tilingPatternExtend(pattern: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -6998,10 +7201,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7039,6 +7244,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7204,6 +7410,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7215,6 +7422,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7223,6 +7431,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7248,6 +7457,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7323,9 +7533,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-windows-x86_64-R4.1.rs
+++ b/bindings/bindings-windows-x86_64-R4.1.rs
@@ -100,7 +100,7 @@ pub const R_GE_patternExtendRepeat: u32 = 2;
 pub const R_GE_patternExtendReflect: u32 = 3;
 pub const R_GE_patternExtendNone: u32 = 4;
 pub const R_PROBLEM_BUFSIZE: u32 = 4096;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __gnuc_va_list;
@@ -213,27 +213,27 @@ fn bindgen_test_layout__iobuf() {
 }
 pub type FILE = _iobuf;
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -348,7 +348,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -385,7 +385,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -408,7 +408,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -431,7 +431,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -464,7 +464,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -499,7 +499,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -520,7 +520,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
-#[doc = " called with a variable argument set"]
+#[doc = "called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -667,7 +667,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -690,7 +690,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -704,9 +704,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe SEXPREC struct below has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -718,7 +718,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the second USE_RINTERNALS section"]
+    #[doc = "Various tests with macro versions in the second USE_RINTERNALS section"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -746,7 +746,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -825,7 +825,7 @@ extern "C" {
     pub fn MARK_ASSIGNMENT_CALL(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -835,7 +835,7 @@ extern "C" {
     pub fn UNSET_S4_OBJECT(x: SEXP);
 }
 extern "C" {
-    #[doc = " JIT optimization support"]
+    #[doc = "JIT optimization support"]
     pub fn NOJIT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -851,14 +851,14 @@ extern "C" {
     pub fn UNSET_MAYBEJIT(x: SEXP);
 }
 extern "C" {
-    #[doc = " Growable vector support"]
+    #[doc = "Growable vector support"]
     pub fn IS_GROWABLE(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn SET_GROWABLE_BIT(x: SEXP);
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -932,7 +932,7 @@ extern "C" {
     pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn STDVEC_DATAPTR(x: SEXP) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -997,7 +997,7 @@ extern "C" {
     pub fn ALTVEC_EXTRACT_SUBSET(x: SEXP, indx: SEXP, call: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " data access"]
+    #[doc = "data access"]
     pub fn ALTINTEGER_ELT(x: SEXP, i: R_xlen_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1059,7 +1059,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1084,7 +1084,7 @@ extern "C" {
     pub fn STRING_NO_NA(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " invoking ALTREP class methods"]
+    #[doc = "invoking ALTREP class methods"]
     pub fn ALTINTEGER_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1132,7 +1132,7 @@ extern "C" {
     pub fn ALTLOGICAL_SUM(x: SEXP, narm: Rboolean) -> SEXP;
 }
 extern "C" {
-    #[doc = " constructors for internal ALTREP classes"]
+    #[doc = "constructors for internal ALTREP classes"]
     pub fn R_compact_intrange(n1: R_xlen_t, n2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -1251,7 +1251,7 @@ extern "C" {
     pub fn CONS_NR(a: SEXP, b: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1288,7 +1288,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1313,7 +1313,7 @@ extern "C" {
     pub fn SET_INTERNAL(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1338,7 +1338,7 @@ extern "C" {
     pub fn SET_HASHTAB(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Promise Access Functions */\n/* First five have macro versions in Defn.h"]
+    #[doc = "Promise Access Functions */\n/* First five have macro versions in Defn.h"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1363,7 +1363,7 @@ extern "C" {
     pub fn SET_PRCODE(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Hashing Functions */\n/* There are macro versions in Defn.h"]
+    #[doc = "Hashing Functions */\n/* There are macro versions in Defn.h"]
     pub fn HASHASH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1375,229 +1375,229 @@ extern "C" {
 extern "C" {
     pub fn SET_HASHVALUE(x: SEXP, v: ::std::os::raw::c_int);
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1643,7 +1643,7 @@ pub const warn_type_iWARN: warn_type = 1;
 pub const warn_type_iERROR: warn_type = 2;
 pub type warn_type = ::std::os::raw::c_uint;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1781,7 +1781,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1934,7 +1934,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -2065,7 +2065,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -2089,11 +2089,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2118,13 +2118,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -2142,7 +2142,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -2191,7 +2191,7 @@ extern "C" {
     pub fn R_reinit_altrep_classes(arg1: *mut DllInfo);
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -2262,7 +2262,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2642,7 +2642,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2652,11 +2652,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2678,7 +2678,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2692,7 +2692,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2711,7 +2711,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2721,14 +2721,14 @@ extern "C" {
     pub fn R_system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
+    #[doc = "R_compute_identical:  C version of identical() function\nThe third arg to R_compute_identical() consists of bitmapped flags for non-default options:\ncurrently the first 4 default to TRUE, so the flag is set for FALSE values:\n1 = !NUM_EQ\n2 = !SINGLE_NA\n4 = !ATTR_AS_SET\n8 = !IGNORE_BYTECODE\n16 = !IGNORE_ENV\nDefault from R's default: 16"]
     pub fn R_compute_identical(arg1: SEXP, arg2: SEXP, arg3: ::std::os::raw::c_int) -> Rboolean;
 }
 extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2738,7 +2738,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -3064,7 +3064,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
@@ -3146,14 +3146,14 @@ extern "C" {
     pub fn readconsolecfg();
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -3923,7 +3923,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -4290,73 +4290,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4515,67 +4515,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4681,12 +4681,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4707,24 +4707,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4735,11 +4735,11 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5514,7 +5514,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5564,12 +5564,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5625,7 +5625,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5635,9 +5635,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5678,23 +5678,23 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
 }
 #[test]
@@ -5888,7 +5888,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -6055,7 +6055,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -6117,7 +6117,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -6146,7 +6146,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -6158,7 +6158,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6244,7 +6244,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6323,7 +6323,7 @@ extern "C" {
     pub fn R_GE_tilingPatternExtend(pattern: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7201,12 +7201,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7244,7 +7244,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7410,7 +7410,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7422,7 +7422,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7431,7 +7431,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7457,7 +7457,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7533,11 +7533,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-windows-x86_64-R4.2.rs
+++ b/bindings/bindings-windows-x86_64-R4.2.rs
@@ -149,7 +149,7 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __gnuc_va_list;
@@ -262,21 +262,27 @@ fn bindgen_test_layout__iobuf() {
 }
 pub type FILE = _iobuf;
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -285,7 +291,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -389,6 +397,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -425,6 +434,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -447,6 +457,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -469,6 +480,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -501,6 +513,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -535,6 +548,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -555,8 +569,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
+#[doc = " called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -620,6 +636,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -699,6 +716,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -721,6 +739,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -734,7 +753,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -746,6 +767,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -773,6 +795,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -803,9 +826,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -851,6 +876,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -894,6 +920,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -972,6 +999,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1008,6 +1036,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1020,6 +1049,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1032,6 +1062,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1044,6 +1075,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1052,176 +1084,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1255,6 +1344,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1339,6 +1429,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1458,6 +1549,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1540,6 +1632,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1563,9 +1656,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1590,11 +1685,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1612,6 +1709,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1636,6 +1734,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -1706,6 +1805,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2082,6 +2182,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2091,9 +2192,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2115,6 +2218,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2128,6 +2232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2146,6 +2251,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2161,6 +2267,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2170,6 +2277,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2179,6 +2287,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the public inlinable functions that are provided in\nRinlinedfuns.h It is *essential* that these do not appear in any\nother header file, with or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2425,6 +2534,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2457,6 +2567,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
+#[doc = " try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2488,6 +2599,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
+    #[doc = " public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2531,6 +2643,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
+    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2598,9 +2711,11 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
@@ -2682,12 +2797,14 @@ extern "C" {
     pub fn readconsolecfg();
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -3466,6 +3583,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -3832,45 +3950,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4029,47 +4175,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4175,10 +4341,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4199,17 +4367,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4220,7 +4395,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4242,6 +4419,7 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5086,6 +5264,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5135,10 +5314,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5194,6 +5375,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5203,7 +5385,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5244,15 +5428,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
+    #[doc = " Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -5444,6 +5638,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -5455,6 +5650,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -5614,12 +5810,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -5681,6 +5879,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -5709,6 +5908,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -5720,6 +5920,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -5805,6 +6006,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -5898,6 +6100,7 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -6763,10 +6966,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -6804,6 +7009,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -6969,6 +7175,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -6980,6 +7187,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -6988,6 +7196,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7013,6 +7222,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7088,9 +7298,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-windows-x86_64-R4.2.rs
+++ b/bindings/bindings-windows-x86_64-R4.2.rs
@@ -149,7 +149,7 @@ pub const R_GE_capability_masks: u32 = 8;
 pub const R_GE_capability_compositing: u32 = 9;
 pub const R_GE_capability_transformations: u32 = 10;
 pub const R_GE_capability_paths: u32 = 11;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __gnuc_va_list;
@@ -262,27 +262,27 @@ fn bindgen_test_layout__iobuf() {
 }
 pub type FILE = _iobuf;
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -397,7 +397,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -434,7 +434,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -457,7 +457,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -480,7 +480,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -513,7 +513,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -548,7 +548,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -569,7 +569,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
-#[doc = " called with a variable argument set"]
+#[doc = "called with a variable argument set"]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -716,7 +716,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -739,7 +739,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -753,9 +753,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -767,7 +767,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the internal headers"]
+    #[doc = "Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -795,7 +795,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -826,11 +826,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -920,7 +920,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -999,7 +999,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1036,7 +1036,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1049,7 +1049,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1062,7 +1062,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Promise Access Functions"]
+    #[doc = "Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1075,7 +1075,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " External pointer access macros"]
+    #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1084,233 +1084,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"@\""]
+    #[doc = "\"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1344,7 +1344,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1429,7 +1429,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1549,7 +1549,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1632,7 +1632,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1656,11 +1656,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1685,13 +1685,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1709,7 +1709,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1734,7 +1734,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -1805,7 +1805,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -2182,7 +2182,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2192,11 +2192,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2218,7 +2218,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2232,7 +2232,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2251,7 +2251,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2267,7 +2267,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2277,7 +2277,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2534,7 +2534,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2567,7 +2567,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
-#[doc = " try to allow some type checking"]
+#[doc = "try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2599,7 +2599,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
-    #[doc = " public C interface"]
+    #[doc = "public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2643,7 +2643,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
-    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
+    #[doc = "stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2711,11 +2711,11 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
+    #[doc = "used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
@@ -2797,14 +2797,14 @@ extern "C" {
     pub fn readconsolecfg();
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -3583,7 +3583,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -3950,73 +3950,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4175,67 +4175,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4341,12 +4341,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4367,24 +4367,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4395,9 +4395,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4419,7 +4419,7 @@ pub struct _DevDesc {
         unsafe extern "C" fn(path: SEXP, rule: ::std::os::raw::c_int, gc: pGEcontext, dd: pDevDesc),
     >,
     pub capabilities: ::std::option::Option<unsafe extern "C" fn(cap: SEXP) -> SEXP>,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5264,7 +5264,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5314,12 +5314,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5375,7 +5375,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5385,9 +5385,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5428,25 +5428,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
-    #[doc = " Is a device appending a path ?"]
+    #[doc = "Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -5650,7 +5650,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -5817,7 +5817,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -5879,7 +5879,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -5908,7 +5908,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -5920,7 +5920,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6006,7 +6006,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6100,7 +6100,7 @@ extern "C" {
     pub fn R_GE_maskType(mask: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -6966,12 +6966,12 @@ extern "C" {
         incx: *const ::std::os::raw::c_int,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7009,7 +7009,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7175,7 +7175,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7187,7 +7187,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7196,7 +7196,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7222,7 +7222,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7298,11 +7298,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-windows-x86_64-R4.3-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.3-devel.rs
@@ -82,8 +82,8 @@ pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
 pub const R_MONTH: &[u8; 3usize] = b"02\0";
-pub const R_DAY: &[u8; 3usize] = b"21\0";
-pub const R_SVN_REVISION: u32 = 83888;
+pub const R_DAY: &[u8; 3usize] = b"26\0";
+pub const R_SVN_REVISION: u32 = 83908;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
@@ -154,7 +154,7 @@ pub const R_GE_capability_glyphs: u32 = 12;
 pub const R_GE_text_style_normal: u32 = 1;
 pub const R_GE_text_style_italic: u32 = 2;
 pub const R_GE_text_style_oblique: u32 = 3;
-#[doc = " <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __gnuc_va_list;
@@ -267,21 +267,27 @@ fn bindgen_test_layout__iobuf() {
 }
 pub type FILE = _iobuf;
 extern "C" {
+    #[doc = " IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
+    #[doc = " IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
+    #[doc = " IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
+    #[doc = " NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
+    #[doc = " NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -290,7 +296,9 @@ extern "C" {
 extern "C" {
     pub fn R_finite(arg1: f64) -> ::std::os::raw::c_int;
 }
+#[doc = ", MAYBE"]
 pub const Rboolean_FALSE: Rboolean = 0;
+#[doc = ", MAYBE"]
 pub const Rboolean_TRUE: Rboolean = 1;
 pub type Rboolean = ::std::os::raw::c_uint;
 #[repr(C)]
@@ -394,6 +402,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
+    #[doc = " ../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -430,6 +439,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -452,6 +462,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -474,6 +485,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
+    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -506,6 +518,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
+    #[doc = " ../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -540,6 +553,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -560,8 +574,10 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
+#[doc = " Called with a variable argument set after casting to a compatible\nfunction pointer."]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_CMethodDef {
@@ -625,6 +641,7 @@ fn bindgen_test_layout_R_CMethodDef() {
         )
     );
 }
+#[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
 pub type R_FortranMethodDef = R_CMethodDef;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -704,6 +721,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
+    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -726,6 +744,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
+    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -739,7 +758,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
+#[doc = " type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
+#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -751,6 +772,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -778,6 +800,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -808,9 +831,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
+    #[doc = " S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -856,6 +881,7 @@ extern "C" {
     pub fn COMPLEX_RO(x: SEXP) -> *const Rcomplex;
 }
 extern "C" {
+    #[doc = "SEXP (STRING_ELT)(SEXP x, R_xlen_t i);"]
     pub fn VECTOR_ELT(x: SEXP, i: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -899,6 +925,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
+    #[doc = " metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -980,6 +1007,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1016,6 +1044,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
+    #[doc = " Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1028,6 +1057,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1040,6 +1070,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1052,6 +1083,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1060,176 +1092,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
+#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
+    #[doc = " The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
+    #[doc = " An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
+    #[doc = " The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
+    #[doc = " Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
+    #[doc = " Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
+    #[doc = " The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
+    #[doc = " Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
+    #[doc = " Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
+    #[doc = " To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
+    #[doc = " Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
+    #[doc = " Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
+    #[doc = " \"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " <-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
+    #[doc = " \".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
+    #[doc = " \".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
+    #[doc = " \".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
+    #[doc = " \".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
+    #[doc = " \".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
+    #[doc = " NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
+    #[doc = " \"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
+    #[doc = " srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1263,6 +1352,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
+    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1347,6 +1437,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1466,6 +1557,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
+#[doc = " ../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1548,6 +1640,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
+#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1579,9 +1672,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1606,11 +1701,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
+    #[doc = " Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
+#[doc = " Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1628,6 +1725,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
+    #[doc = " Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1652,6 +1750,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -1722,6 +1821,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -1770,6 +1870,7 @@ extern "C" {
     pub fn R_HasFancyBindings(rho: SEXP) -> Rboolean;
 }
 extern "C" {
+    #[doc = " ../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
     pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
@@ -2098,6 +2199,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
+    #[doc = " slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2107,9 +2209,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2131,6 +2235,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2144,6 +2249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2162,6 +2268,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2177,6 +2284,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2186,6 +2294,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2195,6 +2304,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = "These are the public inlinable functions that are provided in\nRinlinedfuns.h It is *essential* that these do not appear in any\nother header file, with or without the Rf_ prefix."]
     pub fn Rf_allocVector(arg1: SEXPTYPE, arg2: R_xlen_t) -> SEXP;
 }
 extern "C" {
@@ -2441,6 +2551,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
+    #[doc = " ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2473,6 +2584,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
+#[doc = " try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2504,6 +2616,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
+    #[doc = " public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2547,6 +2660,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
+    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2614,9 +2728,11 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
+    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
+    #[doc = " C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
@@ -2704,12 +2820,14 @@ extern "C" {
     pub fn readconsolecfg();
 }
 extern "C" {
+    #[doc = " R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
+    #[doc = " Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -3488,6 +3606,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
+#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -3854,45 +3973,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
+#[doc = " native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
+#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
+#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
+#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
+#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
+#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
+#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
+#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
+#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
+#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
+#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
+#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
+#[doc = "  Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
+#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
+    #[doc = " pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
+    #[doc = " fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
+    #[doc = " Gamma correction"]
     pub gamma: f64,
+    #[doc = " Line width (roughly number of pixels)"]
     pub lwd: f64,
+    #[doc = " Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
+    #[doc = " Line end"]
     pub lend: R_GE_lineend,
+    #[doc = " line join"]
     pub ljoin: R_GE_linejoin,
+    #[doc = " line mitre"]
     pub lmitre: f64,
+    #[doc = " Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
+    #[doc = " Font size in points"]
     pub ps: f64,
+    #[doc = " Line height (multiply by font size)"]
     pub lineheight: f64,
+    #[doc = " Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
+    #[doc = " Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
+    #[doc = " Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4051,47 +4198,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
+#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " Device physical characteristics"]
+    #[doc = " left raster coordinate"]
     pub left: f64,
+    #[doc = " right raster coordinate"]
     pub right: f64,
+    #[doc = " bottom raster coordinate"]
     pub bottom: f64,
+    #[doc = " top raster coordinate"]
     pub top: f64,
+    #[doc = " R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
+    #[doc = " x character addressing offset - unused"]
     pub xCharOffset: f64,
+    #[doc = " y character addressing offset"]
     pub yCharOffset: f64,
+    #[doc = " 1/2 interline space as frac of line height"]
     pub yLineBias: f64,
+    #[doc = " Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
+    #[doc = " Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
+    #[doc = " (initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device capabilities"]
+    #[doc = " Device-level clipping"]
     pub canClip: Rboolean,
+    #[doc = " can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
+    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings"]
+    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
+    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
+    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " Device specific information"]
+    #[doc = " pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " Device display list"]
+    #[doc = " toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " Event handling entries"]
+    #[doc = " can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
+    #[doc = " can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
+    #[doc = " can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
+    #[doc = " can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
+    #[doc = " can the device generate idle events"]
     pub canGenIdle: Rboolean,
+    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4197,10 +4364,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
+    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
+    #[doc = " and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4221,17 +4390,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
+    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
+    #[doc = " This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
+    #[doc = " 1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4242,7 +4418,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
+    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
+    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4277,6 +4455,7 @@ pub struct _DevDesc {
             dd: pDevDesc,
         ),
     >,
+    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5131,6 +5310,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = " Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5180,10 +5360,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
+#[doc = " These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
+#[doc = " These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5239,6 +5421,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5248,7 +5431,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
+    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
+    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5289,15 +5474,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
+    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
+    #[doc = " toggle for display list status"]
     pub displayListOn: Rboolean,
+    #[doc = " display list"]
     pub displayList: SEXP,
+    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
+    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
+    #[doc = " Has the device received any output?"]
     pub dirty: Rboolean,
+    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
+    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
+    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
+    #[doc = " Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -5489,6 +5684,7 @@ extern "C" {
 extern "C" {
     pub fn GEtoDeviceHeight(value: f64, from: GEUnit, dd: pGEDevDesc) -> f64;
 }
+#[doc = "-------------------------------------------------------------------\n\n  COLOUR CODE is concerned with the internals of R colour representation\n\n  From colors.c, used in par.c, grid/src/gpar.c"]
 pub type rcolor = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_RGBpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> rcolor;
@@ -5500,6 +5696,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
+    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -5659,12 +5856,14 @@ extern "C" {
     pub fn GEstring_to_pch(pch: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
+    #[doc = "-------------------------------------------------------------------\n\n  LINE TEXTURE CODE is concerned with the internals of R\n  line texture representation."]
     pub fn GE_LTYpar(arg1: SEXP, arg2: ::std::os::raw::c_int) -> ::std::os::raw::c_uint;
 }
 extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
+    #[doc = " Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -5726,6 +5925,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -5754,6 +5954,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -5765,6 +5966,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
+    #[doc = " From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -5850,6 +6052,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -5998,6 +6201,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -6955,10 +7159,12 @@ extern "C" {
         arg3: usize,
     );
 }
+#[doc = " ../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
+    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -6996,6 +7202,7 @@ extern "C" {
         work: *mut f64,
     );
 }
+#[doc = " main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7161,6 +7368,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7172,6 +7380,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
+#[doc = " type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7180,6 +7389,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
+#[doc = " type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7205,6 +7415,7 @@ extern "C" {
     );
 }
 extern "C" {
+    #[doc = " Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7280,9 +7491,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
+#[doc = " Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
+#[doc = " Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/bindings/bindings-windows-x86_64-R4.3-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.3-devel.rs
@@ -82,8 +82,8 @@ pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
 pub const R_MONTH: &[u8; 3usize] = b"02\0";
-pub const R_DAY: &[u8; 3usize] = b"26\0";
-pub const R_SVN_REVISION: u32 = 83908;
+pub const R_DAY: &[u8; 3usize] = b"27\0";
+pub const R_SVN_REVISION: u32 = 83911;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
@@ -154,7 +154,7 @@ pub const R_GE_capability_glyphs: u32 = 12;
 pub const R_GE_text_style_normal: u32 = 1;
 pub const R_GE_text_style_italic: u32 = 2;
 pub const R_GE_text_style_oblique: u32 = 3;
-#[doc = " R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
+#[doc = "R_xlen_t is defined as int on 32-bit platforms, and\n that confuses Rust. Keeping it always as ptrdiff_t works\n fine even on 32-bit.\n <div rustbindgen replaces=\"R_xlen_t\"></div>"]
 pub type R_xlen_t = isize;
 pub type __gnuc_va_list = __builtin_va_list;
 pub type va_list = __gnuc_va_list;
@@ -267,27 +267,27 @@ fn bindgen_test_layout__iobuf() {
 }
 pub type FILE = _iobuf;
 extern "C" {
-    #[doc = " IEEE NaN"]
+    #[doc = "IEEE NaN"]
     pub static mut R_NaN: f64;
 }
 extern "C" {
-    #[doc = " IEEE Inf"]
+    #[doc = "IEEE Inf"]
     pub static mut R_PosInf: f64;
 }
 extern "C" {
-    #[doc = " IEEE -Inf"]
+    #[doc = "IEEE -Inf"]
     pub static mut R_NegInf: f64;
 }
 extern "C" {
-    #[doc = " NA_REAL: IEEE"]
+    #[doc = "NA_REAL: IEEE"]
     pub static mut R_NaReal: f64;
 }
 extern "C" {
-    #[doc = " NA_INTEGER:= INT_MIN currently"]
+    #[doc = "NA_INTEGER:= INT_MIN currently"]
     pub static mut R_NaInt: ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " NA_STRING is a SEXP, so defined in Rinternals.h"]
+    #[doc = "NA_STRING is a SEXP, so defined in Rinternals.h"]
     pub fn R_IsNA(arg1: f64) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -402,7 +402,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    #[doc = " ../../main/sort.c :"]
+    #[doc = "../../main/sort.c :"]
     pub fn R_isort(arg1: *mut ::std::os::raw::c_int, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -439,7 +439,7 @@ extern "C" {
     pub fn Rf_cPsort(arg1: *mut Rcomplex, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " ../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
+    #[doc = "../../main/qsort.c : */\n/* dummy renamed to II to avoid problems with g++ on Solaris"]
     pub fn R_qsort(v: *mut f64, i: usize, j: usize);
 }
 extern "C" {
@@ -462,7 +462,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../main/util.c  and others :"]
+    #[doc = "../../main/util.c  and others :"]
     pub fn R_ExpandFileName(arg1: *const ::std::os::raw::c_char) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
@@ -485,7 +485,7 @@ extern "C" {
     pub fn Rf_isBlankString(arg1: *const ::std::os::raw::c_char) -> Rboolean;
 }
 extern "C" {
-    #[doc = " These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
+    #[doc = "These two are guaranteed to use '.' as the decimal point,\nand to accept \"NA\"."]
     pub fn R_atof(str_: *const ::std::os::raw::c_char) -> f64;
 }
 extern "C" {
@@ -518,7 +518,7 @@ extern "C" {
     pub fn R_CheckStack2(arg1: usize);
 }
 extern "C" {
-    #[doc = " ../../appl/interv.c: also in Applic.h"]
+    #[doc = "../../appl/interv.c: also in Applic.h"]
     pub fn findInterval(
         xt: *mut f64,
         n: ::std::os::raw::c_int,
@@ -553,7 +553,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " ../../appl/maxcol.c: also in Applic.h"]
+    #[doc = "../../appl/maxcol.c: also in Applic.h"]
     pub fn R_max_col(
         matrix: *mut f64,
         nr: *mut ::std::os::raw::c_int,
@@ -574,7 +574,7 @@ extern "C" {
 extern "C" {
     pub fn REvprintf(arg1: *const ::std::os::raw::c_char, arg2: va_list);
 }
-#[doc = " Called with a variable argument set after casting to a compatible\nfunction pointer."]
+#[doc = "Called with a variable argument set after casting to a compatible\nfunction pointer."]
 pub type DL_FUNC = ::std::option::Option<unsafe extern "C" fn() -> *mut ::std::os::raw::c_void>;
 pub type R_NativePrimitiveArgType = ::std::os::raw::c_uint;
 #[doc = "These are very similar to those in Rdynpriv.h,\nbut we maintain them separately to give us more freedom to do\nsome computations on the internal versions that are derived from\nthese definitions."]
@@ -721,7 +721,7 @@ extern "C" {
     pub fn R_getDllInfo(name: *const ::std::os::raw::c_char) -> *mut DllInfo;
 }
 extern "C" {
-    #[doc = " To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
+    #[doc = "To be used by applications embedding R to register their symbols\nthat are not related to any dynamic module"]
     pub fn R_getEmbeddingDllInfo() -> *mut DllInfo;
 }
 #[repr(C)]
@@ -744,7 +744,7 @@ extern "C" {
     ) -> DL_FUNC;
 }
 extern "C" {
-    #[doc = " Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
+    #[doc = "Interface for exporting and importing functions from one package\nfor use from C code in a package.  The registration part probably\nought to be integrated with the other registrations.  The naming of\nthese routines may be less than ideal."]
     pub fn R_RegisterCCallable(
         package: *const ::std::os::raw::c_char,
         name: *const ::std::os::raw::c_char,
@@ -758,9 +758,9 @@ extern "C" {
     ) -> DL_FUNC;
 }
 pub type Rbyte = ::std::os::raw::c_uchar;
-#[doc = " type for length of (standard, not long) vectors etc"]
+#[doc = "type for length of (standard, not long) vectors etc"]
 pub type R_len_t = ::std::os::raw::c_int;
-#[doc = " NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
+#[doc = "NOT YET using enum:\n  1)\tThe internal SEXPREC struct has 'SEXPTYPE type : 5'\n\t(making FUNSXP and CLOSXP equivalent in there),\n\tgiving (-Wall only ?) warnings all over the place\n 2)\tMany switch(type) { case ... } statements need a final `default:'\n\tadded in order to avoid warnings like [e.g. l.170 of ../main/util.c]\n\t  \"enumeration value `FUNSXP' not handled in switch\""]
 pub type SEXPTYPE = ::std::os::raw::c_uint;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -772,7 +772,7 @@ extern "C" {
     pub fn R_CHAR(x: SEXP) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Various tests with macro versions in the internal headers"]
+    #[doc = "Various tests with macro versions in the internal headers"]
     pub fn Rf_isNull(s: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -800,7 +800,7 @@ extern "C" {
     pub fn Rf_isObject(s: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " General Cons Cell Attributes"]
+    #[doc = "General Cons Cell Attributes"]
     pub fn ATTRIB(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -831,11 +831,11 @@ extern "C" {
     pub fn MARK_NOT_MUTABLE(x: SEXP);
 }
 extern "C" {
-    #[doc = " S4 object testing"]
+    #[doc = "S4 object testing"]
     pub fn IS_S4_OBJECT(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Vector Access Functions"]
+    #[doc = "Vector Access Functions"]
     pub fn LENGTH(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -925,7 +925,7 @@ extern "C" {
     pub fn RAW_GET_REGION(sx: SEXP, i: R_xlen_t, n: R_xlen_t, buf: *mut Rbyte) -> R_xlen_t;
 }
 extern "C" {
-    #[doc = " metadata access"]
+    #[doc = "metadata access"]
     pub fn INTEGER_IS_SORTED(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -1007,7 +1007,7 @@ extern "C" {
     pub fn SETCAD4R(e: SEXP, y: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Closure Access Functions"]
+    #[doc = "Closure Access Functions"]
     pub fn FORMALS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1044,7 +1044,7 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
 }
 extern "C" {
-    #[doc = " Symbol Access Functions"]
+    #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1057,7 +1057,7 @@ extern "C" {
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Environment Access Functions"]
+    #[doc = "Environment Access Functions"]
     pub fn FRAME(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1070,7 +1070,7 @@ extern "C" {
     pub fn ENVFLAGS(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Promise Access Functions"]
+    #[doc = "Promise Access Functions"]
     pub fn PRCODE(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1083,7 +1083,7 @@ extern "C" {
     pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " External pointer access macros"]
+    #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1092,233 +1092,233 @@ extern "C" {
 extern "C" {
     pub fn EXTPTR_PTR(arg1: SEXP) -> *mut ::std::os::raw::c_void;
 }
-#[doc = " We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
+#[doc = "We sometimes need to coerce a protected value and place the new\ncoerced value under protection.  For these cases PROTECT_WITH_INDEX\nsaves an index of the protection location that can be used to\nreplace the protected value using REPROTECT."]
 pub type PROTECT_INDEX = ::std::os::raw::c_int;
 extern "C" {
-    #[doc = " The \"global\" environment"]
+    #[doc = "The \"global\" environment"]
     pub static mut R_GlobalEnv: SEXP;
 }
 extern "C" {
-    #[doc = " An empty environment at the root of the\nenvironment tree"]
+    #[doc = "An empty environment at the root of the\nenvironment tree"]
     pub static mut R_EmptyEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The base environment; formerly R_NilValue"]
+    #[doc = "The base environment; formerly R_NilValue"]
     pub static mut R_BaseEnv: SEXP;
 }
 extern "C" {
-    #[doc = " The (fake) namespace for base"]
+    #[doc = "The (fake) namespace for base"]
     pub static mut R_BaseNamespace: SEXP;
 }
 extern "C" {
-    #[doc = " Registry for registered namespaces"]
+    #[doc = "Registry for registered namespaces"]
     pub static mut R_NamespaceRegistry: SEXP;
 }
 extern "C" {
-    #[doc = " Current srcref, for debuggers"]
+    #[doc = "Current srcref, for debuggers"]
     pub static mut R_Srcref: SEXP;
 }
 extern "C" {
-    #[doc = " The nil object"]
+    #[doc = "The nil object"]
     pub static mut R_NilValue: SEXP;
 }
 extern "C" {
-    #[doc = " Unbound marker"]
+    #[doc = "Unbound marker"]
     pub static mut R_UnboundValue: SEXP;
 }
 extern "C" {
-    #[doc = " Missing argument marker"]
+    #[doc = "Missing argument marker"]
     pub static mut R_MissingArg: SEXP;
 }
 extern "C" {
-    #[doc = " To be found in BC interp. state\n(marker)"]
+    #[doc = "To be found in BC interp. state\n(marker)"]
     pub static mut R_InBCInterpreter: SEXP;
 }
 extern "C" {
-    #[doc = " Use current expression (marker)"]
+    #[doc = "Use current expression (marker)"]
     pub static mut R_CurrentExpression: SEXP;
 }
 extern "C" {
-    #[doc = " Marker for restarted function calls"]
+    #[doc = "Marker for restarted function calls"]
     pub static mut R_RestartToken: SEXP;
 }
 extern "C" {
-    #[doc = " \"as.character\""]
+    #[doc = "\"as.character\""]
     pub static mut R_AsCharacterSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"@\""]
+    #[doc = "\"@\""]
     pub static mut R_AtsignSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " <-- backcompatible version of:"]
+    #[doc = "<-- backcompatible version of:"]
     pub static mut R_baseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"base\""]
+    #[doc = "\"base\""]
     pub static mut R_BaseSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"{\""]
+    #[doc = "\"{\""]
     pub static mut R_BraceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[[\""]
+    #[doc = "\"[[\""]
     pub static mut R_Bracket2Symbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"[\""]
+    #[doc = "\"[\""]
     pub static mut R_BracketSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"class\""]
+    #[doc = "\"class\""]
     pub static mut R_ClassSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Device\""]
+    #[doc = "\".Device\""]
     pub static mut R_DeviceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dimnames\""]
+    #[doc = "\"dimnames\""]
     pub static mut R_DimNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"dim\""]
+    #[doc = "\"dim\""]
     pub static mut R_DimSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"$\""]
+    #[doc = "\"$\""]
     pub static mut R_DollarSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"...\""]
+    #[doc = "\"...\""]
     pub static mut R_DotsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"::\""]
+    #[doc = "\"::\""]
     pub static mut R_DoubleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"drop\""]
+    #[doc = "\"drop\""]
     pub static mut R_DropSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"eval\""]
+    #[doc = "\"eval\""]
     pub static mut R_EvalSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"function\""]
+    #[doc = "\"function\""]
     pub static mut R_FunctionSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Last.value\""]
+    #[doc = "\".Last.value\""]
     pub static mut R_LastvalueSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"levels\""]
+    #[doc = "\"levels\""]
     pub static mut R_LevelsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"mode\""]
+    #[doc = "\"mode\""]
     pub static mut R_ModeSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"na.rm\""]
+    #[doc = "\"na.rm\""]
     pub static mut R_NaRmSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"name\""]
+    #[doc = "\"name\""]
     pub static mut R_NameSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"names\""]
+    #[doc = "\"names\""]
     pub static mut R_NamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".__NAMESPACE__.\""]
+    #[doc = "\".__NAMESPACE__.\""]
     pub static mut R_NamespaceEnvSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"package\""]
+    #[doc = "\"package\""]
     pub static mut R_PackageSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"previous\""]
+    #[doc = "\"previous\""]
     pub static mut R_PreviousSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"quote\""]
+    #[doc = "\"quote\""]
     pub static mut R_QuoteSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"row.names\""]
+    #[doc = "\"row.names\""]
     pub static mut R_RowNamesSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".Random.seed\""]
+    #[doc = "\".Random.seed\""]
     pub static mut R_SeedsSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"sort.list\""]
+    #[doc = "\"sort.list\""]
     pub static mut R_SortListSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"source\""]
+    #[doc = "\"source\""]
     pub static mut R_SourceSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"spec\""]
+    #[doc = "\"spec\""]
     pub static mut R_SpecSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \":::\""]
+    #[doc = "\":::\""]
     pub static mut R_TripleColonSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \"tsp\""]
+    #[doc = "\"tsp\""]
     pub static mut R_TspSymbol: SEXP;
 }
 extern "C" {
-    #[doc = " \".defined\""]
+    #[doc = "\".defined\""]
     pub static mut R_dot_defined: SEXP;
 }
 extern "C" {
-    #[doc = " \".Method\""]
+    #[doc = "\".Method\""]
     pub static mut R_dot_Method: SEXP;
 }
 extern "C" {
-    #[doc = " \".packageName\""]
+    #[doc = "\".packageName\""]
     pub static mut R_dot_packageName: SEXP;
 }
 extern "C" {
-    #[doc = " \".target\""]
+    #[doc = "\".target\""]
     pub static mut R_dot_target: SEXP;
 }
 extern "C" {
-    #[doc = " \".Generic\""]
+    #[doc = "\".Generic\""]
     pub static mut R_dot_Generic: SEXP;
 }
 extern "C" {
-    #[doc = " NA_STRING as a CHARSXP"]
+    #[doc = "NA_STRING as a CHARSXP"]
     pub static mut R_NaString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a CHARSXP"]
+    #[doc = "\"\" as a CHARSXP"]
     pub static mut R_BlankString: SEXP;
 }
 extern "C" {
-    #[doc = " \"\" as a STRSXP"]
+    #[doc = "\"\" as a STRSXP"]
     pub static mut R_BlankScalarString: SEXP;
 }
 extern "C" {
-    #[doc = " srcref related functions"]
+    #[doc = "srcref related functions"]
     pub fn R_GetCurrentSrcref(arg1: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
     pub fn R_GetSrcFilename(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Type Coercions of all kinds"]
+    #[doc = "Type Coercions of all kinds"]
     pub fn Rf_asChar(arg1: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1352,7 +1352,7 @@ pub struct R_allocator {
 }
 pub type R_allocator_t = R_allocator;
 extern "C" {
-    #[doc = " Other Internally Used Functions, excluding those which are inline-able"]
+    #[doc = "Other Internally Used Functions, excluding those which are inline-able"]
     pub fn Rf_acopy_string(arg1: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1437,7 +1437,7 @@ extern "C" {
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " the next really should not be here and is also in Defn.h"]
+    #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1557,7 +1557,7 @@ extern "C" {
 pub const nchar_type_Bytes: nchar_type = 0;
 pub const nchar_type_Chars: nchar_type = 1;
 pub const nchar_type_Width: nchar_type = 2;
-#[doc = " ../main/character.c :"]
+#[doc = "../main/character.c :"]
 pub type nchar_type = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_nchar(
@@ -1640,7 +1640,7 @@ pub const cetype_t_CE_LATIN1: cetype_t = 2;
 pub const cetype_t_CE_BYTES: cetype_t = 3;
 pub const cetype_t_CE_SYMBOL: cetype_t = 5;
 pub const cetype_t_CE_ANY: cetype_t = 99;
-#[doc = " cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
+#[doc = "cetype_t is an identifier reseved by POSIX, but it is\nwell established as public.  Could remap by a #define though"]
 pub type cetype_t = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_getCharCE(arg1: SEXP) -> cetype_t;
@@ -1672,11 +1672,11 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Calling a function with arguments evaluated"]
+    #[doc = "Calling a function with arguments evaluated"]
     pub fn R_forceAndCall(e: SEXP, n: ::std::os::raw::c_int, rho: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " External pointer interface"]
+    #[doc = "External pointer interface"]
     pub fn R_MakeExternalPtr(p: *mut ::std::os::raw::c_void, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
@@ -1701,13 +1701,13 @@ extern "C" {
     pub fn R_SetExternalPtrProtected(s: SEXP, p: SEXP);
 }
 extern "C" {
-    #[doc = " Added in R 3.4.0"]
+    #[doc = "Added in R 3.4.0"]
     pub fn R_MakeExternalPtrFn(p: DL_FUNC, tag: SEXP, prot: SEXP) -> SEXP;
 }
 extern "C" {
     pub fn R_ExternalPtrAddrFn(s: SEXP) -> DL_FUNC;
 }
-#[doc = " Finalization interface"]
+#[doc = "Finalization interface"]
 pub type R_CFinalizer_t = ::std::option::Option<unsafe extern "C" fn(arg1: SEXP)>;
 extern "C" {
     pub fn R_RegisterFinalizer(s: SEXP, fun: SEXP);
@@ -1725,7 +1725,7 @@ extern "C" {
     pub fn R_RunPendingFinalizers();
 }
 extern "C" {
-    #[doc = " Weak reference interface"]
+    #[doc = "Weak reference interface"]
     pub fn R_MakeWeakRef(key: SEXP, val: SEXP, fin: SEXP, onexit: Rboolean) -> SEXP;
 }
 extern "C" {
@@ -1750,7 +1750,7 @@ extern "C" {
     pub fn R_BytecodeExpr(e: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " Protected evaluation"]
+    #[doc = "Protected evaluation"]
     pub fn R_ToplevelExec(
         fun: ::std::option::Option<unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void)>,
         data: *mut ::std::os::raw::c_void,
@@ -1821,7 +1821,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " Environment and Binding Features"]
+    #[doc = "Environment and Binding Features"]
     pub fn R_NewEnv(arg1: SEXP, arg2: ::std::os::raw::c_int, arg3: ::std::os::raw::c_int) -> SEXP;
 }
 extern "C" {
@@ -1870,7 +1870,7 @@ extern "C" {
     pub fn R_HasFancyBindings(rho: SEXP) -> Rboolean;
 }
 extern "C" {
-    #[doc = " ../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
+    #[doc = "../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
     pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
 }
 extern "C" {
@@ -2199,7 +2199,7 @@ extern "C" {
     pub fn R_SerializeInfo(ips: R_inpstream_t) -> SEXP;
 }
 extern "C" {
-    #[doc = " slot management (in attrib.c)"]
+    #[doc = "slot management (in attrib.c)"]
     pub fn R_do_slot(obj: SEXP, name: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2209,11 +2209,11 @@ extern "C" {
     pub fn R_has_slot(obj: SEXP, name: SEXP) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " S3-S4 class (inheritance), attrib.c"]
+    #[doc = "S3-S4 class (inheritance), attrib.c"]
     pub fn R_S4_extends(klass: SEXP, useTable: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " class definition, new objects (objects.c)"]
+    #[doc = "class definition, new objects (objects.c)"]
     pub fn R_do_MAKE_CLASS(what: *const ::std::os::raw::c_char) -> SEXP;
 }
 extern "C" {
@@ -2235,7 +2235,7 @@ extern "C" {
     pub fn R_do_new_object(class_def: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " supporting  a C-level version of  is(., .) :"]
+    #[doc = "supporting  a C-level version of  is(., .) :"]
     pub fn R_check_class_and_super(
         x: SEXP,
         valid: *mut *const ::std::os::raw::c_char,
@@ -2249,7 +2249,7 @@ extern "C" {
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " preserve objects across GCs"]
+    #[doc = "preserve objects across GCs"]
     pub fn R_PreserveObject(arg1: SEXP);
 }
 extern "C" {
@@ -2268,7 +2268,7 @@ extern "C" {
     pub fn R_ReleaseMSet(mset: SEXP, keepSize: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " Shutdown actions"]
+    #[doc = "Shutdown actions"]
     pub fn R_dot_Last();
 }
 extern "C" {
@@ -2284,7 +2284,7 @@ extern "C" {
     pub fn R_body_no_src(x: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
+    #[doc = "C version of R's  indx <- order(..., na.last, decreasing) :\ne.g.  arglist = Rf_lang2(x,y)  or  Rf_lang3(x,y,z)"]
     pub fn R_orderVector(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2294,7 +2294,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " C version of R's  indx <- order(x, na.last, decreasing) :"]
+    #[doc = "C version of R's  indx <- order(x, na.last, decreasing) :"]
     pub fn R_orderVector1(
         indx: *mut ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -2551,7 +2551,7 @@ extern "C" {
     pub fn SET_RAW_ELT(x: SEXP, i: R_xlen_t, v: Rbyte);
 }
 extern "C" {
-    #[doc = " ALTREP support"]
+    #[doc = "ALTREP support"]
     pub fn ALTREP_CLASS(x: SEXP) -> SEXP;
 }
 extern "C" {
@@ -2584,7 +2584,7 @@ extern "C" {
 extern "C" {
     pub fn ALTREP(x: SEXP) -> ::std::os::raw::c_int;
 }
-#[doc = " try to allow some type checking"]
+#[doc = "try to allow some type checking"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_hashtab_type {
@@ -2616,7 +2616,7 @@ fn bindgen_test_layout_R_hashtab_type() {
     );
 }
 extern "C" {
-    #[doc = " public C interface"]
+    #[doc = "public C interface"]
     pub fn R_asHashtable(h: SEXP) -> R_hashtab_type;
 }
 extern "C" {
@@ -2660,7 +2660,7 @@ extern "C" {
     pub fn R_clrhash(h: R_hashtab_type);
 }
 extern "C" {
-    #[doc = " stuff that probably shouldn't be in the API but is getting used"]
+    #[doc = "stuff that probably shouldn't be in the API but is getting used"]
     pub fn SET_TYPEOF(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
@@ -2728,11 +2728,11 @@ extern "C" {
     pub fn SET_NAMED(x: SEXP, v: ::std::os::raw::c_int);
 }
 extern "C" {
-    #[doc = " used by BIOC::matter; mightbe reasonable to include in API"]
+    #[doc = "used by BIOC::matter; mightbe reasonable to include in API"]
     pub fn R_tryWrap(arg1: SEXP) -> SEXP;
 }
 extern "C" {
-    #[doc = " C stack limit"]
+    #[doc = "C stack limit"]
     pub static mut R_CStackLimit: usize;
 }
 extern "C" {
@@ -2820,14 +2820,14 @@ extern "C" {
     pub fn readconsolecfg();
 }
 extern "C" {
-    #[doc = " R's versions with !R_FINITE checks"]
+    #[doc = "R's versions with !R_FINITE checks"]
     pub fn R_pow(x: f64, y: f64) -> f64;
 }
 extern "C" {
     pub fn R_pow_di(arg1: f64, arg2: ::std::os::raw::c_int) -> f64;
 }
 extern "C" {
-    #[doc = " Random Number Generators"]
+    #[doc = "Random Number Generators"]
     pub fn norm_rand() -> f64;
 }
 extern "C" {
@@ -3606,7 +3606,7 @@ pub const ParseStatus_PARSE_OK: ParseStatus = 1;
 pub const ParseStatus_PARSE_INCOMPLETE: ParseStatus = 2;
 pub const ParseStatus_PARSE_ERROR: ParseStatus = 3;
 pub const ParseStatus_PARSE_EOF: ParseStatus = 4;
-#[doc = " PARSE_NULL will not be returned by R_ParseVector"]
+#[doc = "PARSE_NULL will not be returned by R_ParseVector"]
 pub type ParseStatus = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_ParseVector(
@@ -3973,73 +3973,73 @@ extern "C" {
 extern "C" {
     pub fn R_GE_checkVersionOrDie(version: ::std::os::raw::c_int);
 }
-#[doc = " native device coordinates (rasters)"]
+#[doc = "native device coordinates (rasters)"]
 pub const GEUnit_GE_DEVICE: GEUnit = 0;
-#[doc = " normalised device coordinates x=(0,1), y=(0,1)"]
+#[doc = "normalised device coordinates x=(0,1), y=(0,1)"]
 pub const GEUnit_GE_NDC: GEUnit = 1;
 pub const GEUnit_GE_INCHES: GEUnit = 2;
 pub const GEUnit_GE_CM: GEUnit = 3;
-#[doc = " The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
+#[doc = "The graphics engine will only accept locations and dimensions\n in native device coordinates, but it provides the following functions\n for converting between a couple of simple alternative coordinate\n systems and device coordinates:\n    DEVICE = native units of the device\n    NDC = Normalised device coordinates\n    INCHES = inches (!)\n    CM = centimetres (!!)"]
 pub type GEUnit = ::std::os::raw::c_uint;
-#[doc = " In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
+#[doc = "In response to this event, the registered graphics system\n should allocate and initialise the systemSpecific structure\n\n Should return R_NilValue on failure so that engine\n can tidy up memory allocation"]
 pub const GEevent_GE_InitState: GEevent = 0;
-#[doc = " This event gives the registered system a chance to undo\n anything done in the initialisation."]
+#[doc = "This event gives the registered system a chance to undo\n anything done in the initialisation."]
 pub const GEevent_GE_FinaliseState: GEevent = 1;
-#[doc = " This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
+#[doc = "This is sent by the graphics engine prior to initialising\n the display list.  It give the graphics system the chance\n to squirrel away information it will need for redrawing the\n the display list"]
 pub const GEevent_GE_SaveState: GEevent = 2;
-#[doc = " This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
+#[doc = "This is sent by the graphics engine prior to replaying the\n display list.  It gives the graphics system the chance to\n restore any information it saved on the GE_SaveState event"]
 pub const GEevent_GE_RestoreState: GEevent = 6;
-#[doc = " Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
+#[doc = "Copy system state information to the current device.\n This is used when copying graphics from one device to another\n so all the graphics system needs to do is to copy across\n the bits required for the display list to draw faithfully\n on the new device."]
 pub const GEevent_GE_CopyState: GEevent = 3;
-#[doc = " Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
+#[doc = "Create a snapshot of the system state that is sufficient\n for the current \"image\" to be reproduced"]
 pub const GEevent_GE_SaveSnapshotState: GEevent = 4;
-#[doc = " Restore the system state that is saved by GE_SaveSnapshotState"]
+#[doc = "Restore the system state that is saved by GE_SaveSnapshotState"]
 pub const GEevent_GE_RestoreSnapshotState: GEevent = 5;
-#[doc = " When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
+#[doc = "When replaying the display list, the graphics engine\n checks, after each replayed action, that the action\n produced valid output.  This is the graphics system's\n chance to say that the output is crap (in which case the\n graphics engine will abort the display list replay)."]
 pub const GEevent_GE_CheckPlot: GEevent = 7;
-#[doc = " The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
+#[doc = "The device wants to scale the current pointsize\n (for scaling an image)\n This is not a nice general solution, but a quick fix for\n the Windows device."]
 pub const GEevent_GE_ScalePS: GEevent = 8;
 pub type GEevent = ::std::os::raw::c_uint;
 pub const R_GE_lineend_GE_ROUND_CAP: R_GE_lineend = 1;
 pub const R_GE_lineend_GE_BUTT_CAP: R_GE_lineend = 2;
 pub const R_GE_lineend_GE_SQUARE_CAP: R_GE_lineend = 3;
-#[doc = "  Some line end/join constants"]
+#[doc = "Some line end/join constants"]
 pub type R_GE_lineend = ::std::os::raw::c_uint;
 pub const R_GE_linejoin_GE_ROUND_JOIN: R_GE_linejoin = 1;
 pub const R_GE_linejoin_GE_MITRE_JOIN: R_GE_linejoin = 2;
 pub const R_GE_linejoin_GE_BEVEL_JOIN: R_GE_linejoin = 3;
 pub type R_GE_linejoin = ::std::os::raw::c_uint;
-#[doc = " A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
+#[doc = "A structure containing graphical parameters\n\n This is how graphical parameters are passed from graphics systems\n to the graphics engine AND from the graphics engine to graphics\n devices.\n\n Devices are not *required* to honour graphical parameters\n (e.g., alpha transparency is going to be tough for some)"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct R_GE_gcontext {
-    #[doc = " pen colour (lines, text, borders, ...)"]
+    #[doc = "pen colour (lines, text, borders, ...)"]
     pub col: ::std::os::raw::c_int,
-    #[doc = " fill colour (for polygons, circles, rects, ...)"]
+    #[doc = "fill colour (for polygons, circles, rects, ...)"]
     pub fill: ::std::os::raw::c_int,
-    #[doc = " Gamma correction"]
+    #[doc = "Gamma correction"]
     pub gamma: f64,
-    #[doc = " Line width (roughly number of pixels)"]
+    #[doc = "Line width (roughly number of pixels)"]
     pub lwd: f64,
-    #[doc = " Line type (solid, dashed, dotted, ...)"]
+    #[doc = "Line type (solid, dashed, dotted, ...)"]
     pub lty: ::std::os::raw::c_int,
-    #[doc = " Line end"]
+    #[doc = "Line end"]
     pub lend: R_GE_lineend,
-    #[doc = " line join"]
+    #[doc = "line join"]
     pub ljoin: R_GE_linejoin,
-    #[doc = " line mitre"]
+    #[doc = "line mitre"]
     pub lmitre: f64,
-    #[doc = " Character expansion (font size = fontsize*cex)"]
+    #[doc = "Character expansion (font size = fontsize*cex)"]
     pub cex: f64,
-    #[doc = " Font size in points"]
+    #[doc = "Font size in points"]
     pub ps: f64,
-    #[doc = " Line height (multiply by font size)"]
+    #[doc = "Line height (multiply by font size)"]
     pub lineheight: f64,
-    #[doc = " Font face (plain, italic, bold, ...)"]
+    #[doc = "Font face (plain, italic, bold, ...)"]
     pub fontface: ::std::os::raw::c_int,
-    #[doc = " Font family"]
+    #[doc = "Font family"]
     pub fontfamily: [::std::os::raw::c_char; 201usize],
-    #[doc = " Reference to a pattern fill"]
+    #[doc = "Reference to a pattern fill"]
     pub patternFill: SEXP,
 }
 #[test]
@@ -4198,67 +4198,67 @@ fn bindgen_test_layout_R_GE_gcontext() {
     );
 }
 pub type pGEcontext = *mut R_GE_gcontext;
-#[doc = " --------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
+#[doc = "--------- New (in 1.4.0) device driver structure ---------\n NOTES:\n 1. All locations and dimensions are in device coordinates.\n 2. I found this comment in the doc for dev_Open -- looks nasty\n    Any known instances of such a thing happening?  Should be\n    replaced by a function to query the device for preferred gpars\n    settings? (to be called when the device is initialised)\n\n NOTE that it is perfectly acceptable for this\n function to set generic graphics parameters too\n (i.e., override the generic parameter settings\n which GInit sets up) all at the author's own risk\n of course :)\n\n 3. Do we really need dev_StrWidth as well as dev_MetricInfo?\n    I can see the difference between the two -- its just a\n    question of whether dev_MetricInfo should just return\n    what dev_StrWidth would give if font metric information is\n    not available.  I guess having both allows the developer\n    to decide when to ask for which sort of value, and to decide\n    what to do when font metric information is not available.\n    And why not a dev_StrHeight?\n 4. Should \"ipr\", \"asp\", and \"cra\" be in the device description?\n    If not, then where?\n    I guess they don't need to be if no device makes use of them.\n    On the other hand, they would need to be replaced by a device\n    call that R base graphics could use to get enough information\n    to figure them out.  (e.g., some sort of dpi() function to\n    complement the size() function.)"]
 pub type DevDesc = _DevDesc;
 pub type pDevDesc = *mut DevDesc;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _DevDesc {
-    #[doc = " left raster coordinate"]
+    #[doc = "left raster coordinate"]
     pub left: f64,
-    #[doc = " right raster coordinate"]
+    #[doc = "right raster coordinate"]
     pub right: f64,
-    #[doc = " bottom raster coordinate"]
+    #[doc = "bottom raster coordinate"]
     pub bottom: f64,
-    #[doc = " top raster coordinate"]
+    #[doc = "top raster coordinate"]
     pub top: f64,
-    #[doc = " R only has the notion of a rectangular clipping region"]
+    #[doc = "R only has the notion of a rectangular clipping region"]
     pub clipLeft: f64,
     pub clipRight: f64,
     pub clipBottom: f64,
     pub clipTop: f64,
-    #[doc = " x character addressing offset - unused"]
+    #[doc = "x character addressing offset - unused"]
     pub xCharOffset: f64,
-    #[doc = " y character addressing offset"]
+    #[doc = "y character addressing offset"]
     pub yCharOffset: f64,
-    #[doc = " 1/2 interline space as frac of line height"]
+    #[doc = "1/2 interline space as frac of line height"]
     pub yLineBias: f64,
-    #[doc = " Inches per raster; [0]=x, [1]=y"]
+    #[doc = "Inches per raster; [0]=x, [1]=y"]
     pub ipr: [f64; 2usize],
-    #[doc = " Character size in rasters; [0]=x, [1]=y"]
+    #[doc = "Character size in rasters; [0]=x, [1]=y"]
     pub cra: [f64; 2usize],
-    #[doc = " (initial) Device Gamma Correction"]
+    #[doc = "(initial) Device Gamma Correction"]
     pub gamma: f64,
-    #[doc = " Device-level clipping"]
+    #[doc = "Device-level clipping"]
     pub canClip: Rboolean,
-    #[doc = " can the gamma factor be modified?"]
+    #[doc = "can the gamma factor be modified?"]
     pub canChangeGamma: Rboolean,
-    #[doc = " Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
+    #[doc = "Can do at least some horiz adjust of text\n0 = none, 1 = {0,0.5,1}, 2 = [0,1]"]
     pub canHAdj: ::std::os::raw::c_int,
-    #[doc = " Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
+    #[doc = "Device initial settings\n/\n/* These are things that the device must set up when it is created.\n The graphics system can modify them and track current values,"]
     pub startps: f64,
-    #[doc = " sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
+    #[doc = "sets par(\"fg\"), par(\"col\") and gpar(\"col\")"]
     pub startcol: ::std::os::raw::c_int,
-    #[doc = " sets par(\"bg\") and gpar(\"fill\")"]
+    #[doc = "sets par(\"bg\") and gpar(\"fill\")"]
     pub startfill: ::std::os::raw::c_int,
     pub startlty: ::std::os::raw::c_int,
     pub startfont: ::std::os::raw::c_int,
     pub startgamma: f64,
-    #[doc = " pointer to device specific parameters"]
+    #[doc = "pointer to device specific parameters"]
     pub deviceSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " toggle for initial display list status"]
+    #[doc = "toggle for initial display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " can the device generate mousedown events"]
+    #[doc = "can the device generate mousedown events"]
     pub canGenMouseDown: Rboolean,
-    #[doc = " can the device generate mousemove events"]
+    #[doc = "can the device generate mousemove events"]
     pub canGenMouseMove: Rboolean,
-    #[doc = " can the device generate mouseup events"]
+    #[doc = "can the device generate mouseup events"]
     pub canGenMouseUp: Rboolean,
-    #[doc = " can the device generate keyboard events"]
+    #[doc = "can the device generate keyboard events"]
     pub canGenKeybd: Rboolean,
-    #[doc = " can the device generate idle events"]
+    #[doc = "can the device generate idle events"]
     pub canGenIdle: Rboolean,
-    #[doc = " This is set while getGraphicsEvent\nis actively looking for events"]
+    #[doc = "This is set while getGraphicsEvent\nis actively looking for events"]
     pub gettingEvent: Rboolean,
     pub activate: ::std::option::Option<unsafe extern "C" fn(arg1: pDevDesc)>,
     pub circle: ::std::option::Option<
@@ -4364,12 +4364,12 @@ pub struct _DevDesc {
         ),
     >,
     pub onExit: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc)>,
-    #[doc = " device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
+    #[doc = "device_getEvent is no longer used, but the slot is kept for back\n compatibility of the structure."]
     pub getEvent: ::std::option::Option<
         unsafe extern "C" fn(arg1: SEXP, arg2: *const ::std::os::raw::c_char) -> SEXP,
     >,
     pub newFrameConfirm: ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc) -> Rboolean>,
-    #[doc = " and strWidthUTF8"]
+    #[doc = "and strWidthUTF8"]
     pub hasTextUTF8: Rboolean,
     pub textUTF8: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4390,24 +4390,24 @@ pub struct _DevDesc {
         ) -> f64,
     >,
     pub wantSymbolUTF8: Rboolean,
-    #[doc = " Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
+    #[doc = "Is rotated text good enough to be preferable to Hershey in\ncontour labels?  Old default was FALSE."]
     pub useRotatedTextInContour: Rboolean,
-    #[doc = " This is an environment holding event handlers."]
+    #[doc = "This is an environment holding event handlers."]
     pub eventEnv: SEXP,
     pub eventHelper:
         ::std::option::Option<unsafe extern "C" fn(dd: pDevDesc, code: ::std::os::raw::c_int)>,
     pub holdflush: ::std::option::Option<
         unsafe extern "C" fn(dd: pDevDesc, level: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
     >,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveTransparency: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = fully, 3 = semi"]
+    #[doc = "1 = no, 2 = fully, 3 = semi"]
     pub haveTransparentBg: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes, 3 = except for missing values"]
+    #[doc = "1 = no, 2 = yes, 3 = except for missing values"]
     pub haveRaster: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveCapture: ::std::os::raw::c_int,
-    #[doc = " 1 = no, 2 = yes"]
+    #[doc = "1 = no, 2 = yes"]
     pub haveLocator: ::std::os::raw::c_int,
     pub setPattern:
         ::std::option::Option<unsafe extern "C" fn(pattern: SEXP, dd: pDevDesc) -> SEXP>,
@@ -4418,9 +4418,9 @@ pub struct _DevDesc {
     pub setMask:
         ::std::option::Option<unsafe extern "C" fn(path: SEXP, ref_: SEXP, dd: pDevDesc) -> SEXP>,
     pub releaseMask: ::std::option::Option<unsafe extern "C" fn(ref_: SEXP, dd: pDevDesc)>,
-    #[doc = " This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
+    #[doc = "This should match R_GE_version,\n BUT it does not have to.\n It give the graphics engine a chance to work with\n graphics device packages BEFORE they update to\n changes in R_GE_version."]
     pub deviceVersion: ::std::os::raw::c_int,
-    #[doc = " This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
+    #[doc = "This can be used to OVERRIDE canClip so that graphics engine\n leaves ALL clipping to the graphics device"]
     pub deviceClip: Rboolean,
     pub defineGroup: ::std::option::Option<
         unsafe extern "C" fn(
@@ -4455,7 +4455,7 @@ pub struct _DevDesc {
             dd: pDevDesc,
         ),
     >,
-    #[doc = " Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
+    #[doc = "Area for future expansion.\nBy zeroing this, devices are more likely to work if loaded\ninto a later version of R than that they were compiled under."]
     pub reserved: [::std::os::raw::c_char; 64usize],
 }
 #[test]
@@ -5310,7 +5310,7 @@ extern "C" {
     pub fn Rf_NumDevices() -> ::std::os::raw::c_int;
 }
 extern "C" {
-    #[doc = " Check for an available device slot"]
+    #[doc = "Check for an available device slot"]
     pub fn R_CheckDeviceAvailable();
 }
 extern "C" {
@@ -5360,12 +5360,12 @@ pub const R_KeyName_knEND: R_KeyName = 18;
 pub const R_KeyName_knHOME: R_KeyName = 19;
 pub const R_KeyName_knINS: R_KeyName = 20;
 pub const R_KeyName_knDEL: R_KeyName = 21;
-#[doc = " These give the indices of some known keys"]
+#[doc = "These give the indices of some known keys"]
 pub type R_KeyName = ::std::os::raw::c_int;
 pub const R_MouseEvent_meMouseDown: R_MouseEvent = 0;
 pub const R_MouseEvent_meMouseUp: R_MouseEvent = 1;
 pub const R_MouseEvent_meMouseMove: R_MouseEvent = 2;
-#[doc = " These are the three possible mouse events"]
+#[doc = "These are the three possible mouse events"]
 pub type R_MouseEvent = ::std::os::raw::c_uint;
 extern "C" {
     pub fn Rf_doMouseEvent(
@@ -5421,7 +5421,7 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Translates Unicode point to UTF-8"]
+    #[doc = "Translates Unicode point to UTF-8"]
     pub fn Rf_ucstoutf8(s: *mut ::std::os::raw::c_char, c: ::std::os::raw::c_uint) -> usize;
 }
 pub type GEDevDesc = _GEDevDesc;
@@ -5431,9 +5431,9 @@ pub type GEcallback = ::std::option::Option<
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct GESystemDesc {
-    #[doc = " An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
+    #[doc = "An array of information about each graphics system that\n has registered with the graphics engine.\n This is used to store graphics state for each graphics\n system on each device."]
     pub systemSpecific: *mut ::std::os::raw::c_void,
-    #[doc = " An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
+    #[doc = "An array of function pointers, one per graphics system that\n has registered with the graphics engine.\n\n system_Callback is called when the graphics engine wants\n to give a graphics system the chance to play with its\n device-specific information (stored in systemSpecific)\n There are two parameters:  an \"event\" to tell the graphics\n system why the graphics engine has called this function,\n and the systemSpecific pointer.  The graphics engine\n has to pass the systemSpecific pointer because only\n the graphics engine will know what array index to use."]
     pub callback: GEcallback,
 }
 #[test]
@@ -5474,25 +5474,25 @@ fn bindgen_test_layout_GESystemDesc() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _GEDevDesc {
-    #[doc = " Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
+    #[doc = "Stuff that the devices can see (and modify).\n All detailed in GraphicsDevice.h"]
     pub dev: pDevDesc,
-    #[doc = " toggle for display list status"]
+    #[doc = "toggle for display list status"]
     pub displayListOn: Rboolean,
-    #[doc = " display list"]
+    #[doc = "display list"]
     pub displayList: SEXP,
-    #[doc = " A pointer to the end of the display list\nto avoid tranversing pairlists"]
+    #[doc = "A pointer to the end of the display list\nto avoid tranversing pairlists"]
     pub DLlastElt: SEXP,
-    #[doc = " The last element of the display list\n just prior to when the display list\n was last initialised"]
+    #[doc = "The last element of the display list\n just prior to when the display list\n was last initialised"]
     pub savedSnapshot: SEXP,
-    #[doc = " Has the device received any output?"]
+    #[doc = "Has the device received any output?"]
     pub dirty: Rboolean,
-    #[doc = " Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
+    #[doc = "Should a graphics call be stored\n on the display list?\n Set to FALSE by do_recordGraphics,\n do_dotcallgr, and do_Externalgr\n so that nested calls are not\n recorded on the display list"]
     pub recordGraphics: Rboolean,
-    #[doc = " Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
+    #[doc = "Stuff about the device that only graphics systems see.\n The graphics engine has no idea what is in here.\n Used by graphics systems to store system state per device."]
     pub gesd: [*mut GESystemDesc; 24usize],
-    #[doc = " per-device setting for 'ask' (use NewFrameConfirm)"]
+    #[doc = "per-device setting for 'ask' (use NewFrameConfirm)"]
     pub ask: Rboolean,
-    #[doc = " Is a device appending a path ?"]
+    #[doc = "Is a device appending a path ?"]
     pub appending: Rboolean,
 }
 #[test]
@@ -5696,7 +5696,7 @@ extern "C" {
     pub fn Rf_col2name(col: rcolor) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    #[doc = " Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
+    #[doc = "Convert either a name or a #RRGGBB[AA] string to internal.\nBecause people were using it, it also converts \"1\", \"2\" ...\nto a colour in the palette, and \"0\" to transparent white."]
     pub fn R_GE_str2col(s: *const ::std::os::raw::c_char) -> rcolor;
 }
 extern "C" {
@@ -5863,7 +5863,7 @@ extern "C" {
     pub fn GE_LTYget(arg1: ::std::os::raw::c_uint) -> SEXP;
 }
 extern "C" {
-    #[doc = " Raster operations"]
+    #[doc = "Raster operations"]
     pub fn R_GE_rasterScale(
         sraster: *mut ::std::os::raw::c_uint,
         sw: ::std::os::raw::c_int,
@@ -5925,7 +5925,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plotmath.c"]
+    #[doc = "From plotmath.c"]
     pub fn GEExpressionWidth(expr: SEXP, gc: pGEcontext, dd: pGEDevDesc) -> f64;
 }
 extern "C" {
@@ -5954,7 +5954,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " From plot3d.c : used in package clines"]
+    #[doc = "From plot3d.c : used in package clines"]
     pub fn GEcontourLines(
         x: *mut f64,
         nx: ::std::os::raw::c_int,
@@ -5966,7 +5966,7 @@ extern "C" {
     ) -> SEXP;
 }
 extern "C" {
-    #[doc = " From vfonts.c"]
+    #[doc = "From vfonts.c"]
     pub fn R_GE_VStrWidth(
         s: *const ::std::os::raw::c_char,
         enc: cetype_t,
@@ -6052,7 +6052,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Patterns - from ../../main/patterns.c"]
+    #[doc = "Patterns - from ../../main/patterns.c"]
     pub fn R_GE_isPattern(x: SEXP) -> Rboolean;
 }
 extern "C" {
@@ -6201,7 +6201,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " S Like Memory Management"]
+    #[doc = "S Like Memory Management"]
     pub fn R_chk_calloc(arg1: usize, arg2: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -7159,12 +7159,12 @@ extern "C" {
         arg3: usize,
     );
 }
-#[doc = " ../../appl/integrate.c"]
+#[doc = "../../appl/integrate.c"]
 pub type integr_fn = ::std::option::Option<
     unsafe extern "C" fn(x: *mut f64, n: ::std::os::raw::c_int, ex: *mut ::std::os::raw::c_void),
 >;
 extern "C" {
-    #[doc = " vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
+    #[doc = "vectorizing function   f(x[1:n], ...) -> x[]  {overwriting x[]}."]
     pub fn Rdqags(
         f: integr_fn,
         ex: *mut ::std::os::raw::c_void,
@@ -7202,7 +7202,7 @@ extern "C" {
         work: *mut f64,
     );
 }
-#[doc = " main/optim.c"]
+#[doc = "main/optim.c"]
 pub type optimfn = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7368,7 +7368,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " appl/pretty.c: for use in engine.c and util.c"]
+    #[doc = "appl/pretty.c: for use in engine.c and util.c"]
     pub fn R_pretty(
         lo: *mut f64,
         up: *mut f64,
@@ -7380,7 +7380,7 @@ extern "C" {
         return_bounds: ::std::os::raw::c_int,
     ) -> f64;
 }
-#[doc = " type of pointer to the target and gradient functions"]
+#[doc = "type of pointer to the target and gradient functions"]
 pub type fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7389,7 +7389,7 @@ pub type fcn_p = ::std::option::Option<
         arg4: *mut ::std::os::raw::c_void,
     ),
 >;
-#[doc = " type of pointer to the hessian functions"]
+#[doc = "type of pointer to the hessian functions"]
 pub type d2fcn_p = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -7415,7 +7415,7 @@ extern "C" {
     );
 }
 extern "C" {
-    #[doc = " Also used in packages nlme, pcaPP"]
+    #[doc = "Also used in packages nlme, pcaPP"]
     pub fn optif9(
         nr: ::std::os::raw::c_int,
         n: ::std::os::raw::c_int,
@@ -7491,11 +7491,11 @@ pub const N01type_BOX_MULLER: N01type = 2;
 pub const N01type_USER_NORM: N01type = 3;
 pub const N01type_INVERSION: N01type = 4;
 pub const N01type_KINDERMAN_RAMAGE: N01type = 5;
-#[doc = " Different kinds of \"N(0,1)\" generators :"]
+#[doc = "Different kinds of \"N(0,1)\" generators :"]
 pub type N01type = ::std::os::raw::c_uint;
 pub const Sampletype_ROUNDING: Sampletype = 0;
 pub const Sampletype_REJECTION: Sampletype = 1;
-#[doc = " Different ways to generate discrete uniform samples"]
+#[doc = "Different ways to generate discrete uniform samples"]
 pub type Sampletype = ::std::os::raw::c_uint;
 extern "C" {
     pub fn R_sample_kind() -> Sampletype;

--- a/build.rs
+++ b/build.rs
@@ -484,7 +484,7 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         "Generating bindings for target: {}, os: {}, architecture: {}",
         target, target_os, target_arch
     );
-    
+
     // Point to the correct headers
     bindgen_builder = bindgen_builder.clang_args(&[
         format!("-I{}", r_paths.include.display()),
@@ -509,6 +509,9 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
 
     // Finish the builder and generate the bindings.
     let bindings = bindgen_builder
+        .generate_comments(true)
+        .clang_arg("-fparse-all-comments")
+        .clang_arg("-fretain-comments-from-system-headers")
         .generate()
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");

--- a/build.rs
+++ b/build.rs
@@ -591,6 +591,7 @@ fn retrieve_prebuild_bindings(version_info: &RVersionInfo) {
 #[derive(Debug)]
 struct RCallbacks;
 
+#[cfg(feature = "use-bindgen")]
 impl bindgen::callbacks::ParseCallbacks for RCallbacks {
     fn process_comment(&self, comment: &str) -> Option<String> {
         let trim_comment = comment.trim();

--- a/build.rs
+++ b/build.rs
@@ -510,6 +510,7 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
     // Finish the builder and generate the bindings.
     let bindings = bindgen_builder
         .generate_comments(true)
+        .parse_callbacks(Box::new(RCallbacks))
         .clang_arg("-fparse-all-comments")
         .clang_arg("-fretain-comments-from-system-headers")
         .generate()
@@ -584,6 +585,17 @@ fn retrieve_prebuild_bindings(version_info: &RVersionInfo) {
     )
     .expect("No precomputed bindings available!");
     println!("cargo:rerun-if-changed={}", from.display());
+}
+
+/// Provide extra cleaning of the processed elements in the headers.
+#[derive(Debug)]
+struct RCallbacks;
+
+impl bindgen::callbacks::ParseCallbacks for RCallbacks {
+    fn process_comment(&self, comment: &str) -> Option<String> {
+        let trim_comment = comment.trim();
+        Some(trim_comment.to_string())
+    }
 }
 
 fn main() {

--- a/build.rs
+++ b/build.rs
@@ -512,7 +512,6 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         .generate_comments(true)
         .parse_callbacks(Box::new(RCallbacks))
         .clang_arg("-fparse-all-comments")
-        // .clang_arg("-fretain-comments-from-system-headers")
         .generate()
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");

--- a/build.rs
+++ b/build.rs
@@ -348,7 +348,7 @@ fn get_r_version(
         Ok(v) => Ok(v),
         // If the envvar is not present, then use the actual R binary to get the version.
         Err(EnvVarError::EnvVarNotPresent) => get_r_version_from_r(r_paths),
-        // In the case of any error other than the absense of envvar, stop with
+        // In the case of any error other than the absence of envvar, stop with
         // that error because it means the envvar is set and something is wrong.
         e @ Err(_) => e,
     }
@@ -389,7 +389,7 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         .unwrap();
 
     // Extract all the AST entities into `e`, as well as listing up all the
-    // include files in a chain into `inclide_files`.
+    // include files in a chain into `include_files`.
     let mut include_files = std::collections::HashSet::new();
     let e = tu
         .get_entity()
@@ -429,7 +429,7 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         }
     }
 
-    // Do some regex-fu agaist the text content of all the include files. This
+    // Do some regex-fu against the text content of all the include files. This
     // handles these 3 cases:
     //
     // case 1) numeric literals
@@ -455,7 +455,7 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         }
     }
 
-    // This cannot be detected because the #define-ed constats are aliased in another #define
+    // This cannot be detected because the #define-ed constants are aliased in another #define
     // c.f. https://github.com/wch/r-source/blob/9f284035b7e503aebe4a804579e9e80a541311bb/src/include/R_ext/GraphicsEngine.h#L93
     allowlist.insert("R_GE_version".to_string());
 
@@ -484,6 +484,7 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         "Generating bindings for target: {}, os: {}, architecture: {}",
         target, target_os, target_arch
     );
+    
     // Point to the correct headers
     bindgen_builder = bindgen_builder.clang_args(&[
         format!("-I{}", r_paths.include.display()),
@@ -512,6 +513,8 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");
 
+    bindings.emit_warnings();
+
     // Write the bindings to the $OUT_DIR/bindings.rs file.
     let out_path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
@@ -519,7 +522,7 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings to default output path!");
 
-    // Also write the bindings to a folder specified by LIBRSYS_BINDINGS_OUTPUT_PATH, if defined
+    // Also write the bindings to a folder specified by `LIBRSYS_BINDINGS_OUTPUT_PATH`, if defined
     if let Some(alt_target) = env::var_os(ENVVAR_BINDINGS_OUTPUT_PATH) {
         let out_path = PathBuf::from(alt_target);
         // if folder doesn't exist, try to create it

--- a/build.rs
+++ b/build.rs
@@ -512,7 +512,7 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         .generate_comments(true)
         .parse_callbacks(Box::new(RCallbacks))
         .clang_arg("-fparse-all-comments")
-        .clang_arg("-fretain-comments-from-system-headers")
+        // .clang_arg("-fretain-comments-from-system-headers")
         .generate()
         // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");


### PR DESCRIPTION
Adding these lines to the `clang`-call enables getting some comments.

This is not much, but it is *something*. Maybe it will be more useful later