### PR TITLE
Define NORET manually

### DIFF
--- a/bindings/bindings-linux-aarch64-R4.3-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.3-devel.rs
@@ -162,9 +162,9 @@ pub const R_MAJOR: &[u8; 2usize] = b"4\0";
 pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
-pub const R_MONTH: &[u8; 3usize] = b"02\0";
-pub const R_DAY: &[u8; 3usize] = b"27\0";
-pub const R_SVN_REVISION: u32 = 83911;
+pub const R_MONTH: &[u8; 3usize] = b"03\0";
+pub const R_DAY: &[u8; 3usize] = b"08\0";
+pub const R_SVN_REVISION: u32 = 83956;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
@@ -672,13 +672,13 @@ fn bindgen_test_layout_Rcomplex() {
     );
 }
 extern "C" {
-    pub fn Rf_error(arg1: *const ::std::os::raw::c_char, ...);
+    pub fn Rf_error(arg1: *const ::std::os::raw::c_char, ...) -> !;
 }
 extern "C" {
-    pub fn UNIMPLEMENTED(arg1: *const ::std::os::raw::c_char);
+    pub fn UNIMPLEMENTED(arg1: *const ::std::os::raw::c_char) -> !;
 }
 extern "C" {
-    pub fn WrongArgCount(arg1: *const ::std::os::raw::c_char);
+    pub fn WrongArgCount(arg1: *const ::std::os::raw::c_char) -> !;
 }
 extern "C" {
     pub fn Rf_warning(arg1: *const ::std::os::raw::c_char, ...);
@@ -1226,7 +1226,7 @@ extern "C" {
     pub fn STRING_PTR_RO(x: SEXP) -> *const SEXP;
 }
 extern "C" {
-    pub fn VECTOR_PTR(x: SEXP) -> *mut SEXP;
+    pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
     pub fn INTEGER_GET_REGION(
@@ -2136,7 +2136,7 @@ extern "C" {
     pub fn R_MakeUnwindCont() -> SEXP;
 }
 extern "C" {
-    pub fn R_ContinueUnwind(cont: SEXP);
+    pub fn R_ContinueUnwind(cont: SEXP) -> !;
 }
 extern "C" {
     pub fn R_UnwindProtect(
@@ -2200,7 +2200,7 @@ extern "C" {
 }
 extern "C" {
     #[doc = "../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
-    pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
+    pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...) -> !;
 }
 extern "C" {
     pub fn Rf_warningcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
@@ -4199,6 +4199,13 @@ extern "C" {
     ) -> R_altrep_class_t;
 }
 extern "C" {
+    pub fn R_make_altlist_class(
+        cname: *const ::std::os::raw::c_char,
+        pname: *const ::std::os::raw::c_char,
+        info: *mut DllInfo,
+    ) -> R_altrep_class_t;
+}
+extern "C" {
     pub fn R_altrep_inherits(x: SEXP, arg1: R_altrep_class_t) -> Rboolean;
 }
 pub type R_altrep_UnserializeEX_method_t = ::std::option::Option<
@@ -4321,6 +4328,10 @@ pub type R_altstring_Is_sorted_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP) -> ::std::os::raw::c_int>;
 pub type R_altstring_No_NA_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP) -> ::std::os::raw::c_int>;
+pub type R_altlist_Elt_method_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: R_xlen_t) -> SEXP>;
+pub type R_altlist_Set_elt_method_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: R_xlen_t, arg3: SEXP)>;
 extern "C" {
     pub fn R_set_altrep_UnserializeEX_method(
         cls: R_altrep_class_t,
@@ -4473,6 +4484,12 @@ extern "C" {
 }
 extern "C" {
     pub fn R_set_altstring_No_NA_method(cls: R_altrep_class_t, fun: R_altstring_No_NA_method_t);
+}
+extern "C" {
+    pub fn R_set_altlist_Elt_method(cls: R_altrep_class_t, fun: R_altlist_Elt_method_t);
+}
+extern "C" {
+    pub fn R_set_altlist_Set_elt_method(cls: R_altrep_class_t, fun: R_altlist_Set_elt_method_t);
 }
 extern "C" {
     pub fn R_GE_getVersion() -> ::std::os::raw::c_int;

--- a/bindings/bindings-linux-x86_64-R4.3-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.3-devel.rs
@@ -162,9 +162,9 @@ pub const R_MAJOR: &[u8; 2usize] = b"4\0";
 pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
-pub const R_MONTH: &[u8; 3usize] = b"02\0";
-pub const R_DAY: &[u8; 3usize] = b"27\0";
-pub const R_SVN_REVISION: u32 = 83911;
+pub const R_MONTH: &[u8; 3usize] = b"03\0";
+pub const R_DAY: &[u8; 3usize] = b"08\0";
+pub const R_SVN_REVISION: u32 = 83956;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
@@ -672,13 +672,13 @@ fn bindgen_test_layout_Rcomplex() {
     );
 }
 extern "C" {
-    pub fn Rf_error(arg1: *const ::std::os::raw::c_char, ...);
+    pub fn Rf_error(arg1: *const ::std::os::raw::c_char, ...) -> !;
 }
 extern "C" {
-    pub fn UNIMPLEMENTED(arg1: *const ::std::os::raw::c_char);
+    pub fn UNIMPLEMENTED(arg1: *const ::std::os::raw::c_char) -> !;
 }
 extern "C" {
-    pub fn WrongArgCount(arg1: *const ::std::os::raw::c_char);
+    pub fn WrongArgCount(arg1: *const ::std::os::raw::c_char) -> !;
 }
 extern "C" {
     pub fn Rf_warning(arg1: *const ::std::os::raw::c_char, ...);
@@ -1226,7 +1226,7 @@ extern "C" {
     pub fn STRING_PTR_RO(x: SEXP) -> *const SEXP;
 }
 extern "C" {
-    pub fn VECTOR_PTR(x: SEXP) -> *mut SEXP;
+    pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
     pub fn INTEGER_GET_REGION(
@@ -2136,7 +2136,7 @@ extern "C" {
     pub fn R_MakeUnwindCont() -> SEXP;
 }
 extern "C" {
-    pub fn R_ContinueUnwind(cont: SEXP);
+    pub fn R_ContinueUnwind(cont: SEXP) -> !;
 }
 extern "C" {
     pub fn R_UnwindProtect(
@@ -2200,7 +2200,7 @@ extern "C" {
 }
 extern "C" {
     #[doc = "../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
-    pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
+    pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...) -> !;
 }
 extern "C" {
     pub fn Rf_warningcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
@@ -4199,6 +4199,13 @@ extern "C" {
     ) -> R_altrep_class_t;
 }
 extern "C" {
+    pub fn R_make_altlist_class(
+        cname: *const ::std::os::raw::c_char,
+        pname: *const ::std::os::raw::c_char,
+        info: *mut DllInfo,
+    ) -> R_altrep_class_t;
+}
+extern "C" {
     pub fn R_altrep_inherits(x: SEXP, arg1: R_altrep_class_t) -> Rboolean;
 }
 pub type R_altrep_UnserializeEX_method_t = ::std::option::Option<
@@ -4321,6 +4328,10 @@ pub type R_altstring_Is_sorted_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP) -> ::std::os::raw::c_int>;
 pub type R_altstring_No_NA_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP) -> ::std::os::raw::c_int>;
+pub type R_altlist_Elt_method_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: R_xlen_t) -> SEXP>;
+pub type R_altlist_Set_elt_method_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: R_xlen_t, arg3: SEXP)>;
 extern "C" {
     pub fn R_set_altrep_UnserializeEX_method(
         cls: R_altrep_class_t,
@@ -4473,6 +4484,12 @@ extern "C" {
 }
 extern "C" {
     pub fn R_set_altstring_No_NA_method(cls: R_altrep_class_t, fun: R_altstring_No_NA_method_t);
+}
+extern "C" {
+    pub fn R_set_altlist_Elt_method(cls: R_altrep_class_t, fun: R_altlist_Elt_method_t);
+}
+extern "C" {
+    pub fn R_set_altlist_Set_elt_method(cls: R_altrep_class_t, fun: R_altlist_Set_elt_method_t);
 }
 extern "C" {
     pub fn R_GE_getVersion() -> ::std::os::raw::c_int;

--- a/bindings/bindings-macos-x86_64-R4.3-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.3-devel.rs
@@ -163,8 +163,8 @@ pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
 pub const R_MONTH: &[u8; 3usize] = b"03\0";
-pub const R_DAY: &[u8; 3usize] = b"01\0";
-pub const R_SVN_REVISION: u32 = 83918;
+pub const R_DAY: &[u8; 3usize] = b"08\0";
+pub const R_SVN_REVISION: u32 = 83956;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
@@ -625,13 +625,13 @@ fn bindgen_test_layout_Rcomplex() {
     );
 }
 extern "C" {
-    pub fn Rf_error(arg1: *const ::std::os::raw::c_char, ...);
+    pub fn Rf_error(arg1: *const ::std::os::raw::c_char, ...) -> !;
 }
 extern "C" {
-    pub fn UNIMPLEMENTED(arg1: *const ::std::os::raw::c_char);
+    pub fn UNIMPLEMENTED(arg1: *const ::std::os::raw::c_char) -> !;
 }
 extern "C" {
-    pub fn WrongArgCount(arg1: *const ::std::os::raw::c_char);
+    pub fn WrongArgCount(arg1: *const ::std::os::raw::c_char) -> !;
 }
 extern "C" {
     pub fn Rf_warning(arg1: *const ::std::os::raw::c_char, ...);
@@ -1179,7 +1179,7 @@ extern "C" {
     pub fn STRING_PTR_RO(x: SEXP) -> *const SEXP;
 }
 extern "C" {
-    pub fn VECTOR_PTR(x: SEXP) -> *mut SEXP;
+    pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
     pub fn INTEGER_GET_REGION(
@@ -2089,7 +2089,7 @@ extern "C" {
     pub fn R_MakeUnwindCont() -> SEXP;
 }
 extern "C" {
-    pub fn R_ContinueUnwind(cont: SEXP);
+    pub fn R_ContinueUnwind(cont: SEXP) -> !;
 }
 extern "C" {
     pub fn R_UnwindProtect(
@@ -2153,7 +2153,7 @@ extern "C" {
 }
 extern "C" {
     #[doc = "../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
-    pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
+    pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...) -> !;
 }
 extern "C" {
     pub fn Rf_warningcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);

--- a/bindings/bindings-windows-x86_64-R4.3-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.3-devel.rs
@@ -82,8 +82,8 @@ pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
 pub const R_MONTH: &[u8; 3usize] = b"02\0";
-pub const R_DAY: &[u8; 3usize] = b"27\0";
-pub const R_SVN_REVISION: u32 = 83911;
+pub const R_DAY: &[u8; 3usize] = b"23\0";
+pub const R_SVN_REVISION: u32 = 83894;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
@@ -343,13 +343,13 @@ fn bindgen_test_layout_Rcomplex() {
     );
 }
 extern "C" {
-    pub fn Rf_error(arg1: *const ::std::os::raw::c_char, ...);
+    pub fn Rf_error(arg1: *const ::std::os::raw::c_char, ...) -> !;
 }
 extern "C" {
-    pub fn UNIMPLEMENTED(arg1: *const ::std::os::raw::c_char);
+    pub fn UNIMPLEMENTED(arg1: *const ::std::os::raw::c_char) -> !;
 }
 extern "C" {
-    pub fn WrongArgCount(arg1: *const ::std::os::raw::c_char);
+    pub fn WrongArgCount(arg1: *const ::std::os::raw::c_char) -> !;
 }
 extern "C" {
     pub fn Rf_warning(arg1: *const ::std::os::raw::c_char, ...);
@@ -897,7 +897,7 @@ extern "C" {
     pub fn STRING_PTR_RO(x: SEXP) -> *const SEXP;
 }
 extern "C" {
-    pub fn VECTOR_PTR(x: SEXP) -> *mut SEXP;
+    pub fn VECTOR_PTR(x: SEXP) -> !;
 }
 extern "C" {
     pub fn INTEGER_GET_REGION(
@@ -1807,7 +1807,7 @@ extern "C" {
     pub fn R_MakeUnwindCont() -> SEXP;
 }
 extern "C" {
-    pub fn R_ContinueUnwind(cont: SEXP);
+    pub fn R_ContinueUnwind(cont: SEXP) -> !;
 }
 extern "C" {
     pub fn R_UnwindProtect(
@@ -1871,7 +1871,7 @@ extern "C" {
 }
 extern "C" {
     #[doc = "../main/errors.c : */\n/* needed for R_load/savehistory handling in front ends"]
-    pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);
+    pub fn Rf_errorcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...) -> !;
 }
 extern "C" {
     pub fn Rf_warningcall(arg1: SEXP, arg2: *const ::std::os::raw::c_char, ...);

--- a/bindings/bindings-windows-x86_64-R4.3-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.3-devel.rs
@@ -81,9 +81,9 @@ pub const R_MAJOR: &[u8; 2usize] = b"4\0";
 pub const R_MINOR: &[u8; 4usize] = b"3.0\0";
 pub const R_STATUS: &[u8; 29usize] = b"Under development (unstable)\0";
 pub const R_YEAR: &[u8; 5usize] = b"2023\0";
-pub const R_MONTH: &[u8; 3usize] = b"02\0";
-pub const R_DAY: &[u8; 3usize] = b"23\0";
-pub const R_SVN_REVISION: u32 = 83894;
+pub const R_MONTH: &[u8; 3usize] = b"03\0";
+pub const R_DAY: &[u8; 3usize] = b"08\0";
+pub const R_SVN_REVISION: u32 = 83956;
 pub const R_GE_definitions: u32 = 13;
 pub const R_GE_deviceClip: u32 = 14;
 pub const R_GE_group: u32 = 15;
@@ -3641,6 +3641,13 @@ extern "C" {
     ) -> R_altrep_class_t;
 }
 extern "C" {
+    pub fn R_make_altlist_class(
+        cname: *const ::std::os::raw::c_char,
+        pname: *const ::std::os::raw::c_char,
+        info: *mut DllInfo,
+    ) -> R_altrep_class_t;
+}
+extern "C" {
     pub fn R_altrep_inherits(x: SEXP, arg1: R_altrep_class_t) -> Rboolean;
 }
 pub type R_altrep_UnserializeEX_method_t = ::std::option::Option<
@@ -3763,6 +3770,10 @@ pub type R_altstring_Is_sorted_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP) -> ::std::os::raw::c_int>;
 pub type R_altstring_No_NA_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP) -> ::std::os::raw::c_int>;
+pub type R_altlist_Elt_method_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: R_xlen_t) -> SEXP>;
+pub type R_altlist_Set_elt_method_t =
+    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: R_xlen_t, arg3: SEXP)>;
 extern "C" {
     pub fn R_set_altrep_UnserializeEX_method(
         cls: R_altrep_class_t,
@@ -3915,6 +3926,12 @@ extern "C" {
 }
 extern "C" {
     pub fn R_set_altstring_No_NA_method(cls: R_altrep_class_t, fun: R_altstring_No_NA_method_t);
+}
+extern "C" {
+    pub fn R_set_altlist_Elt_method(cls: R_altrep_class_t, fun: R_altlist_Elt_method_t);
+}
+extern "C" {
+    pub fn R_set_altlist_Set_elt_method(cls: R_altrep_class_t, fun: R_altlist_Set_elt_method_t);
 }
 extern "C" {
     pub fn R_GE_getVersion() -> ::std::os::raw::c_int;

--- a/wrapper.h
+++ b/wrapper.h
@@ -10,6 +10,12 @@ typedef ptrdiff_t R_xlen_t_rust;
 // #define HAVE_UINTPTR_T
 #define CSTACK_DEFNS
 
+// From r83513 (R 4.3), R defines the `NORET` macro differently depending on the
+// C/C++ standard the compiler uses. It matters when the header is used in C/C++
+// libraries, but all we want to do here is to make bindgen interpret `NOREP` to
+// `!`. However, for some reason, bindgen doesn't handle other no-return
+// attributes like `_Noreturn` (for C11) and `[[noreturn]]` (for C++ and C23),
+// so we define it here.
 #define NORET __attribute__((__noreturn__))
 
 // Currently, I'm adding these on as-needed basis

--- a/wrapper.h
+++ b/wrapper.h
@@ -10,6 +10,8 @@ typedef ptrdiff_t R_xlen_t_rust;
 // #define HAVE_UINTPTR_T
 #define CSTACK_DEFNS
 
+#define NORET __attribute__((__noreturn__))
+
 // Currently, I'm adding these on as-needed basis
 // but we may simply throw the whole lot in in the future.
 #include <Rinternals.h>


### PR DESCRIPTION
Note: I chose `__attribute__((__noreturn__))` instead of `__attribute__((noreturn))` as this is suggested on the following SO.

https://stackoverflow.com/a/28556713