### PR TITLE
[PoC] Test against the generated bindings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,14 +206,20 @@ jobs:
           LIBRSYS_BINDINGS_OUTPUT_PATH: generated_bindings
           RUST_TARGET: ${{ matrix.config.target }}
 
+      # Remove the existing ones to ensure the test will be done agaist the
+      # newly generated ones.
+      - name: Remove the existing bindings
+        run: Remove-Item -Recurse bindings/
+
       # Test the result of previous step
-      - name: Run tests
+      - name: Run tests against the generated bindings
         id: test
         if: matrix.config.skip-tests != 'true'
         run: |
           . ./ci-cargo.ps1
-          ci-cargo test -vv --features use-bindgen $(if ($env:RUST_TARGET -ne '') {"--target=$env:RUST_TARGET"} ) '--' --nocapture --test-threads=1 -ActionName "Running bindgen tests for target: $env:RUST_TARGET"
+          ci-cargo test -vv $(if ($env:RUST_TARGET -ne '') {"--target=$env:RUST_TARGET"} ) '--' --nocapture --test-threads=1 -ActionName "Running bindgen tests for target: $env:RUST_TARGET"
         env:
+          LIBRSYS_BINDINGS_PATH: generated_bindings
           RUST_TARGET: ${{ matrix.config.target }}
 
       - name: Upload generated bindings
@@ -224,15 +230,6 @@ jobs:
         with:
           name: generated_binding-${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}-${{ matrix.config.target || 'default'}}
           path: generated_bindings
-
-      # Run tests again using different bindings
-      - name: Run tests on precomputed bindings shipped with libR-sys
-        if: matrix.config.skip-tests != 'true'
-        run: |
-          . ./ci-cargo.ps1
-          ci-cargo test -vv $(if ($env:RUST_TARGET -ne '') {"--target=$env:RUST_TARGET"} ) '--' --nocapture --test-threads=1 -ActionName "Running tests for target: $env:RUST_TARGET"
-        env:
-          RUST_TARGET: ${{ matrix.config.target }}
 
   # Gather the generated bindings and push them to generated_bindings branch.
   # If we need to update the bindings, create a pull request from that branch.


### PR DESCRIPTION
This pull request is to show how to fix this: https://github.com/extendr/libR-sys/pull/156#issuecomment-1506827762

Currently, what the CI does is:

1. `cargo build` with the `use-bindgen` feature to generate bindings to `generated_bindings/`
2. `cargo test` with the `use-bindgen` feature, but without setting `LIBRSYS_BINDINGS_OUTPUT_PATH`
3. upload the generated bindings
4. `cargo test` without the `use-bindgen` feature

I think there are two problems here:

1. The intent of the last step should be to ensure the generated bindings will work on non-`use-bindgen` cases, but it actually uses the unchanged bindings in `bindings/`.
2. As the second step doesn't set `LIBRSYS_BINDINGS_OUTPUT_PATH`, it might use a different bindings file, which means the uploaded bindings file might be a different one than the tested one.

https://github.com/extendr/libR-sys/blob/df48d3974e89aaccbaf8c53e22b6f2f9b0a772cf/.github/workflows/test.yml#L206-L260