### PR TITLE
Use rust constants and rust types in bindgen

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -507,6 +507,7 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         .allowlist_function(&allowlist_pattern)
         .allowlist_var(&allowlist_pattern)
         .allowlist_type(&allowlist_pattern)
+        .translate_enum_integer_types(true)
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")

--- a/build.rs
+++ b/build.rs
@@ -546,6 +546,23 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
             .blocklist_item("__mingw_ldbl_type_t");
     }
 
+    // Remove constants defined by C-headers and use available rust deifnitions
+    let bindgen_builder = bindgen_builder
+        // redefined in `lib.rs`
+        .blocklist_item("M_E")
+        .blocklist_item("M_LOG2E")
+        .blocklist_item("M_LOG10E")
+        .blocklist_item("M_LN2")
+        .blocklist_item("M_LN10")
+        .blocklist_item("M_PI")
+        .blocklist_item("M_PI_2")
+        .blocklist_item("M_PI_4")
+        .blocklist_item("M_1_PI")
+        .blocklist_item("M_2_PI")
+        .blocklist_item("M_2_SQRTPI")
+        .blocklist_item("M_SQRT2")
+        .blocklist_item("M_SQRT1_2");
+
     // Finish the builder and generate the bindings.
     let bindings = bindgen_builder
         .generate_comments(true)

--- a/build.rs
+++ b/build.rs
@@ -546,9 +546,9 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
             .blocklist_item("__mingw_ldbl_type_t");
     }
 
-    // Remove constants defined by C-headers and use available rust deifnitions
+    // Remove constants defined by C-headers as
+    // there are rust equivalents for them.
     let bindgen_builder = bindgen_builder
-        // redefined in `lib.rs`
         .blocklist_item("M_E")
         .blocklist_item("M_LOG2E")
         .blocklist_item("M_LOG10E")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,20 +66,6 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-pub const M_E: f64 = std::f64::consts::E;
-pub const M_LOG2E: f64 = std::f64::consts::LOG2_E;
-pub const M_LOG10E: f64 = std::f64::consts::LOG10_E;
-pub const M_LN2: f64 = std::f64::consts::LN_2;
-pub const M_LN10: f64 = std::f64::consts::LN_10;
-pub const M_PI: f64 = std::f64::consts::PI;
-pub const M_PI_2: f64 = std::f64::consts::FRAC_PI_2;
-pub const M_PI_4: f64 = std::f64::consts::FRAC_PI_4;
-pub const M_1_PI: f64 = std::f64::consts::FRAC_1_PI;
-pub const M_2_PI: f64 = std::f64::consts::FRAC_2_PI;
-pub const M_2_SQRTPI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
-pub const M_SQRT2: f64 = std::f64::consts::SQRT_2;
-pub const M_SQRT1_2: f64 = std::f64::consts::FRAC_1_SQRT_2;
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,20 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
+pub const M_E: f64 = std::f64::consts::E;
+pub const M_LOG2E: f64 = std::f64::consts::LOG2_E;
+pub const M_LOG10E: f64 = std::f64::consts::LOG10_E;
+pub const M_LN2: f64 = std::f64::consts::LN_2;
+pub const M_LN10: f64 = std::f64::consts::LN_10;
+pub const M_PI: f64 = std::f64::consts::PI;
+pub const M_PI_2: f64 = std::f64::consts::FRAC_PI_2;
+pub const M_PI_4: f64 = std::f64::consts::FRAC_PI_4;
+pub const M_1_PI: f64 = std::f64::consts::FRAC_1_PI;
+pub const M_2_PI: f64 = std::f64::consts::FRAC_2_PI;
+pub const M_2_SQRTPI: f64 = std::f64::consts::FRAC_2_SQRT_PI;
+pub const M_SQRT2: f64 = std::f64::consts::SQRT_2;
+pub const M_SQRT1_2: f64 = std::f64::consts::FRAC_1_SQRT_2;
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
In continuing the effort to clean-up and smooth out libR-sys, I have found that clippy complains about these constants, and we can replace c-types with rust types by this setting.

This will need to be checked more thoroughly with extendr though.
