### PR TITLE
Remove `VECTOR_PTR` from bindings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -512,6 +512,9 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
         .blocklist_item("M_SQRT2")
         .blocklist_item("M_SQRT1_2");
 
+    // `VECTOR_PTR` is deprecated, use `DATAPTR` and friends instead
+    let bindgen_builder = bindgen_builder.blocklist_item("VECTOR_PTR");
+
     // Finish the builder and generate the bindings.
     let bindings = bindgen_builder
         .raw_line(format!(


### PR DESCRIPTION
This should have happened with https://github.com/extendr/libR-sys/issues/144. 

Best source I can found on the deprecated status of `VECTOR_PTR` (except the r-source in #144), is
> (There is STRING_PTR() which is used in a handful of places in the R source; VECTOR_PTR() is a deprecated interface that now throws an error.)

in https://github.com/hadley/r-internals/blob/master/vectors.md
