### PR TITLE
Update actions/deploy-pages to v2

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -49,4 +49,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
For some reason, deployment to GitHub Pages now fails.

https://github.com/extendr/libR-sys/actions/runs/5474800792

Not sure if this can solve the problem, but I just found deploy-pages action now has v2.