### PR TITLE
Fix Documents action

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
 
+      # As of v1.0.9, upload-pages-artifact action rejects files with incorrect permissions.
+      # In Rust doc's case, .lock is such a file.
+      #
+      # cf. https://github.com/actions/deploy-pages/issues/188#issuecomment-1597651901
+      - name: Remove unnecessary files
+        run: rm -f ./target/doc/.lock
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
As of v1.0.9, which was released 3 weeks ago, actions/upload-pages-artifact rejects files with incorrect permission. Before that, the action kindly corrected the permission, so our CI passed with this warning:

```
Warning: mode of './target/doc/.lock' changed from 0600 (rw-------) to 0644 (rw-r--r--)
```
(<https://github.com/extendr/libR-sys/actions/runs/5113126789/jobs/9191980916#step:6:31>)

But, now, it's our job to handle these files. This pull request removes the unused file `.lock`.

See https://github.com/actions/deploy-pages/issues/188 for more details.