### PR TITLE
Skip doctest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,8 @@ clang = { version = "2", optional = true, features = ["runtime", "clang_3_7"] }
 # By default, we use pre-computed bindings that ship with the library. This may fail!
 # Turn on the 'use-bindgen' feature to generate bindings on the fly for your platform.
 use-bindgen = ["bindgen", "clang"]
+
+[lib]
+# Some code comments on R's source code might be accidentally treated as Rust's
+# doc test. See https://github.com/extendr/libR-sys/issues/194 for the details.
+doctest = false


### PR DESCRIPTION
Fix https://github.com/extendr/libR-sys/issues/194

While they are code comments for R's source code, cargo considers them as Rust code because they are unfortunately indented by 4 white spaces, which means cargo tries to run doctests on the code. I think libR-sys will never introduce doctests because most of the APIs cannot run without an R session, so it's fine to disable them all.