### PR TITLE
Ensure layout-tests are present when running with `feature = layout_tests`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clang = { version = "2", optional = true, features = ["runtime", "clang_3_7"] }
 # Turn on the 'use-bindgen' feature to generate bindings on the fly for your platform.
 use-bindgen = ["bindgen", "clang"]
 # Enables generation of layout-tests in bindgen
-layout_tests = []
+layout_tests = ["use-bindgen"]
 
 [lib]
 # Some code comments on R's source code might be accidentally treated as Rust's


### PR DESCRIPTION
Minor adjustment to #196. If the feature `layout_tests` is used, then nothing happens, unless `use-bindgen` is also included. Because layout-tests aren't included in the precomputed bindings.

Therefore, we amend `layout_tests`, such that they always include `use-bindgen`. This isn't a problem in CI, because there we use `use-bindgen` as well.
