### PR TITLE
`TYPEOF` should return `SEXPTYPE`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -520,6 +520,9 @@ fn generate_bindings(r_paths: &InstallationPaths, version_info: &RVersionInfo) {
     // Remove all Fortran items, these are items with underscore _ postfix
     let bindgen_builder = bindgen_builder.blocklist_item("[A-Za-z_][A-Za-z0-9_]*[^_]_$");
 
+    // Replace `TYPEOF` definition with one that gives same type as `SEXPTYPE`.
+    let bindgen_builder = bindgen_builder.blocklist_item("TYPEOF");
+
     // Finish the builder and generate the bindings.
     let bindings = bindgen_builder
         .raw_line(format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,11 @@
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
+extern "C" {
+    // Return type should match `SEXPTYPE`
+    pub fn TYPEOF(x: SEXP) -> ::std::os::raw::c_uint;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,7 +144,7 @@ mod tests {
         unsafe {
             let val = Rf_protect(R_ParseEvalString(cstr!("1"), R_NilValue));
             Rf_PrintValue(val);
-            assert_eq!(TYPEOF(val) as u32, REALSXP);
+            assert_eq!(TYPEOF(val), REALSXP);
             assert_eq!(*REAL(val), 1.);
             Rf_unprotect(1);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 extern "C" {
     // Return type should match `SEXPTYPE`
-    pub fn TYPEOF(x: SEXP) -> ::std::os::raw::c_uint;
+    pub fn TYPEOF(x: SEXP) -> SEXPTYPE;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`TYPEOF` returns the `SEXPTYPE` of a `SEXP`. But the types don't match. This PR fixes #183.