### PR TITLE
Use v4 of upload/download-artifact action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,7 @@ jobs:
         if:
           steps.build.outcome == 'success' &&
           matrix.config.emit-bindings == 'true'
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v4
         with:
           name: generated_binding-${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}-${{ matrix.config.target || 'default'}}
           path: generated_bindings
@@ -247,7 +247,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
 
     - name: Switch branch
       if: github.event_name != 'issue_comment'


### PR DESCRIPTION
Fix #213 

It seems the problem is the version mismatch between `upload-artifact` action and `download-artifact` action; the former specifies `main` while the latter `v3`. Since v4 was released on December 15th, now `upload-artifact` is v4, but the `download-action` stays v3.