### PR TITLE
Modify bindings to generate an emscripten target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -335,6 +335,12 @@ jobs:
           # Choose the newest version except for devel
           ln --force -s "$(ls -1 ./bindings-${x}-*.rs | grep -v devel | sort | tail -1)" ./bindings-${x}.rs
         done
+
+        # Copy linux-x86_64 bindings to emscripten-wasm32
+        for file in ./bindings-linux-x86_64-*.rs; do
+          cp "$file" "${file/linux-x86_64/emscripten-wasm32}"
+        done
+
         cd ..
 
         # detect changes (the code is derived from https://stackoverflow.com/a/3879077)


### PR DESCRIPTION
The PR adds emscripten-wasm32 bindings **enabling extendr to work with webr**. 
This PR modifies the yml to also generate emscripten bindings. We have tested and compiled `rsgeo` to wasm using this approach. 
