### PR TITLE
Manual update of non-API

### DIFF
--- a/bindings/bindings-linux-aarch64-R4.2.rs
+++ b/bindings/bindings-linux-aarch64-R4.2.rs
@@ -1616,7 +1616,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-aarch64-R4.2.rs
+++ b/bindings/bindings-linux-aarch64-R4.2.rs
@@ -1900,8 +1900,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-linux-aarch64-R4.2.rs
+++ b/bindings/bindings-linux-aarch64-R4.2.rs
@@ -1592,7 +1592,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-linux-aarch64-R4.3.rs
+++ b/bindings/bindings-linux-aarch64-R4.3.rs
@@ -1932,8 +1932,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-linux-aarch64-R4.3.rs
+++ b/bindings/bindings-linux-aarch64-R4.3.rs
@@ -1640,7 +1640,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-aarch64-R4.3.rs
+++ b/bindings/bindings-linux-aarch64-R4.3.rs
@@ -1616,7 +1616,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-linux-aarch64-R4.4-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.4-devel.rs
@@ -1423,7 +1423,6 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
     #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
-    pub fn SYMVALUE(x: SEXP) -> SEXP;
     pub fn INTERNAL(x: SEXP) -> SEXP;
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "Environment Access Functions"]

--- a/bindings/bindings-linux-aarch64-R4.4-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.4-devel.rs
@@ -1616,7 +1616,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-aarch64-R4.4-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.4-devel.rs
@@ -1435,7 +1435,6 @@ extern "C" {
     pub fn PRCODE(x: SEXP) -> SEXP;
     pub fn PRENV(x: SEXP) -> SEXP;
     pub fn PRVALUE(x: SEXP) -> SEXP;
-    pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
     pub fn EXTPTR_TAG(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-aarch64-R4.4-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.4-devel.rs
@@ -1591,7 +1591,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-linux-aarch64-R4.4-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.4-devel.rs
@@ -1920,8 +1920,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-linux-aarch64-R4.4.rs
+++ b/bindings/bindings-linux-aarch64-R4.4.rs
@@ -1642,7 +1642,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-aarch64-R4.4.rs
+++ b/bindings/bindings-linux-aarch64-R4.4.rs
@@ -1936,8 +1936,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-linux-aarch64-R4.4.rs
+++ b/bindings/bindings-linux-aarch64-R4.4.rs
@@ -1618,7 +1618,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-linux-aarch64-R4.5-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.5-devel.rs
@@ -1613,7 +1613,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-linux-aarch64-R4.5-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.5-devel.rs
@@ -1929,8 +1929,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-linux-aarch64-R4.5-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.5-devel.rs
@@ -1639,7 +1639,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.2.rs
+++ b/bindings/bindings-linux-x86_64-R4.2.rs
@@ -1601,7 +1601,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.2.rs
+++ b/bindings/bindings-linux-x86_64-R4.2.rs
@@ -1909,8 +1909,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-linux-x86_64-R4.2.rs
+++ b/bindings/bindings-linux-x86_64-R4.2.rs
@@ -1625,7 +1625,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.3.rs
+++ b/bindings/bindings-linux-x86_64-R4.3.rs
@@ -1649,7 +1649,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.3.rs
+++ b/bindings/bindings-linux-x86_64-R4.3.rs
@@ -1941,8 +1941,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-linux-x86_64-R4.3.rs
+++ b/bindings/bindings-linux-x86_64-R4.3.rs
@@ -1625,7 +1625,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.4-devel.rs
@@ -1432,7 +1432,6 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
     #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
-    pub fn SYMVALUE(x: SEXP) -> SEXP;
     pub fn INTERNAL(x: SEXP) -> SEXP;
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "Environment Access Functions"]

--- a/bindings/bindings-linux-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.4-devel.rs
@@ -1600,7 +1600,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.4-devel.rs
@@ -1444,7 +1444,6 @@ extern "C" {
     pub fn PRCODE(x: SEXP) -> SEXP;
     pub fn PRENV(x: SEXP) -> SEXP;
     pub fn PRVALUE(x: SEXP) -> SEXP;
-    pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
     pub fn EXTPTR_TAG(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.4-devel.rs
@@ -1625,7 +1625,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.4-devel.rs
@@ -1929,8 +1929,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-linux-x86_64-R4.4.rs
+++ b/bindings/bindings-linux-x86_64-R4.4.rs
@@ -1651,7 +1651,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.4.rs
+++ b/bindings/bindings-linux-x86_64-R4.4.rs
@@ -1627,7 +1627,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.4.rs
+++ b/bindings/bindings-linux-x86_64-R4.4.rs
@@ -1945,8 +1945,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-linux-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.5-devel.rs
@@ -1938,8 +1938,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-linux-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.5-devel.rs
@@ -1648,7 +1648,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-linux-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.5-devel.rs
@@ -1622,7 +1622,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-macos-aarch64-R4.2.rs
+++ b/bindings/bindings-macos-aarch64-R4.2.rs
@@ -1602,7 +1602,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-macos-aarch64-R4.2.rs
+++ b/bindings/bindings-macos-aarch64-R4.2.rs
@@ -1626,7 +1626,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-aarch64-R4.2.rs
+++ b/bindings/bindings-macos-aarch64-R4.2.rs
@@ -1910,8 +1910,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-macos-aarch64-R4.3.rs
+++ b/bindings/bindings-macos-aarch64-R4.3.rs
@@ -1650,7 +1650,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-aarch64-R4.3.rs
+++ b/bindings/bindings-macos-aarch64-R4.3.rs
@@ -1626,7 +1626,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-macos-aarch64-R4.3.rs
+++ b/bindings/bindings-macos-aarch64-R4.3.rs
@@ -1942,8 +1942,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-macos-aarch64-R4.4.rs
+++ b/bindings/bindings-macos-aarch64-R4.4.rs
@@ -1654,7 +1654,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-aarch64-R4.4.rs
+++ b/bindings/bindings-macos-aarch64-R4.4.rs
@@ -1948,8 +1948,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-macos-aarch64-R4.4.rs
+++ b/bindings/bindings-macos-aarch64-R4.4.rs
@@ -1630,7 +1630,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-macos-aarch64-R4.5-devel.rs
+++ b/bindings/bindings-macos-aarch64-R4.5-devel.rs
@@ -1650,7 +1650,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-aarch64-R4.5-devel.rs
+++ b/bindings/bindings-macos-aarch64-R4.5-devel.rs
@@ -1940,8 +1940,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-macos-aarch64-R4.5-devel.rs
+++ b/bindings/bindings-macos-aarch64-R4.5-devel.rs
@@ -1624,7 +1624,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.2.rs
+++ b/bindings/bindings-macos-x86_64-R4.2.rs
@@ -1610,7 +1610,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.2.rs
+++ b/bindings/bindings-macos-x86_64-R4.2.rs
@@ -1634,7 +1634,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.2.rs
+++ b/bindings/bindings-macos-x86_64-R4.2.rs
@@ -1918,8 +1918,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-macos-x86_64-R4.3.rs
+++ b/bindings/bindings-macos-x86_64-R4.3.rs
@@ -1499,7 +1499,6 @@ extern "C" {
     pub fn PRCODE(x: SEXP) -> SEXP;
     pub fn PRENV(x: SEXP) -> SEXP;
     pub fn PRVALUE(x: SEXP) -> SEXP;
-    pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
     pub fn EXTPTR_TAG(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.3.rs
+++ b/bindings/bindings-macos-x86_64-R4.3.rs
@@ -1983,8 +1983,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-macos-x86_64-R4.3.rs
+++ b/bindings/bindings-macos-x86_64-R4.3.rs
@@ -1656,7 +1656,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.3.rs
+++ b/bindings/bindings-macos-x86_64-R4.3.rs
@@ -1487,7 +1487,6 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
     #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
-    pub fn SYMVALUE(x: SEXP) -> SEXP;
     pub fn INTERNAL(x: SEXP) -> SEXP;
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "Environment Access Functions"]

--- a/bindings/bindings-macos-x86_64-R4.3.rs
+++ b/bindings/bindings-macos-x86_64-R4.3.rs
@@ -1681,7 +1681,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.4-devel.rs
@@ -1610,7 +1610,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.4-devel.rs
@@ -1454,7 +1454,6 @@ extern "C" {
     pub fn PRCODE(x: SEXP) -> SEXP;
     pub fn PRENV(x: SEXP) -> SEXP;
     pub fn PRVALUE(x: SEXP) -> SEXP;
-    pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
     pub fn EXTPTR_TAG(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.4-devel.rs
@@ -1939,8 +1939,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-macos-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.4-devel.rs
@@ -1442,7 +1442,6 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
     #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
-    pub fn SYMVALUE(x: SEXP) -> SEXP;
     pub fn INTERNAL(x: SEXP) -> SEXP;
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "Environment Access Functions"]

--- a/bindings/bindings-macos-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.4-devel.rs
@@ -1635,7 +1635,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.4.rs
+++ b/bindings/bindings-macos-x86_64-R4.4.rs
@@ -1638,7 +1638,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.4.rs
+++ b/bindings/bindings-macos-x86_64-R4.4.rs
@@ -1662,7 +1662,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.4.rs
+++ b/bindings/bindings-macos-x86_64-R4.4.rs
@@ -1956,8 +1956,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-macos-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.5-devel.rs
@@ -1642,7 +1642,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.5-devel.rs
@@ -1971,8 +1971,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-macos-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.5-devel.rs
@@ -1667,7 +1667,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.5-devel.rs
@@ -1486,7 +1486,6 @@ extern "C" {
     pub fn PRCODE(x: SEXP) -> SEXP;
     pub fn PRENV(x: SEXP) -> SEXP;
     pub fn PRVALUE(x: SEXP) -> SEXP;
-    pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
     pub fn EXTPTR_TAG(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-macos-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.5-devel.rs
@@ -1474,7 +1474,6 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
     #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
-    pub fn SYMVALUE(x: SEXP) -> SEXP;
     pub fn INTERNAL(x: SEXP) -> SEXP;
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "Environment Access Functions"]

--- a/bindings/bindings-windows-x86_64-R4.2.rs
+++ b/bindings/bindings-windows-x86_64-R4.2.rs
@@ -1414,7 +1414,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.2.rs
+++ b/bindings/bindings-windows-x86_64-R4.2.rs
@@ -1390,7 +1390,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.2.rs
+++ b/bindings/bindings-windows-x86_64-R4.2.rs
@@ -1698,8 +1698,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-windows-x86_64-R4.3.rs
+++ b/bindings/bindings-windows-x86_64-R4.3.rs
@@ -1414,7 +1414,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.3.rs
+++ b/bindings/bindings-windows-x86_64-R4.3.rs
@@ -1730,8 +1730,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-windows-x86_64-R4.3.rs
+++ b/bindings/bindings-windows-x86_64-R4.3.rs
@@ -1438,7 +1438,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.4-devel.rs
@@ -1234,7 +1234,6 @@ extern "C" {
     pub fn PRCODE(x: SEXP) -> SEXP;
     pub fn PRENV(x: SEXP) -> SEXP;
     pub fn PRVALUE(x: SEXP) -> SEXP;
-    pub fn PRSEEN(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "External pointer access macros"]
     pub fn EXTPTR_PROT(arg1: SEXP) -> SEXP;
     pub fn EXTPTR_TAG(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.4-devel.rs
@@ -1719,8 +1719,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-windows-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.4-devel.rs
@@ -1222,7 +1222,6 @@ extern "C" {
     pub fn SET_CLOENV(x: SEXP, v: SEXP);
     #[doc = "Symbol Access Functions"]
     pub fn PRINTNAME(x: SEXP) -> SEXP;
-    pub fn SYMVALUE(x: SEXP) -> SEXP;
     pub fn INTERNAL(x: SEXP) -> SEXP;
     pub fn DDVAL(x: SEXP) -> ::std::os::raw::c_int;
     #[doc = "Environment Access Functions"]

--- a/bindings/bindings-windows-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.4-devel.rs
@@ -1390,7 +1390,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.4-devel.rs
@@ -1415,7 +1415,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.4.rs
+++ b/bindings/bindings-windows-x86_64-R4.4.rs
@@ -1736,8 +1736,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;

--- a/bindings/bindings-windows-x86_64-R4.4.rs
+++ b/bindings/bindings-windows-x86_64-R4.4.rs
@@ -1418,7 +1418,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.4.rs
+++ b/bindings/bindings-windows-x86_64-R4.4.rs
@@ -1442,7 +1442,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.5-devel.rs
@@ -1412,7 +1412,6 @@ extern "C" {
     pub fn Rf_duplicate(arg1: SEXP) -> SEXP;
     pub fn Rf_shallow_duplicate(arg1: SEXP) -> SEXP;
     pub fn R_duplicate_attr(arg1: SEXP) -> SEXP;
-    pub fn R_shallow_duplicate_attr(arg1: SEXP) -> SEXP;
     pub fn Rf_lazy_duplicate(arg1: SEXP) -> SEXP;
     #[doc = "the next really should not be here and is also in Defn.h"]
     pub fn Rf_duplicated(arg1: SEXP, arg2: Rboolean) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.5-devel.rs
@@ -1438,7 +1438,6 @@ extern "C" {
     pub fn Rf_GetOptionDigits() -> ::std::os::raw::c_int;
     pub fn Rf_GetOptionWidth() -> ::std::os::raw::c_int;
     pub fn Rf_GetRowNames(arg1: SEXP) -> SEXP;
-    pub fn Rf_gsetVar(arg1: SEXP, arg2: SEXP, arg3: SEXP);
     pub fn Rf_install(arg1: *const ::std::os::raw::c_char) -> SEXP;
     pub fn Rf_installChar(arg1: SEXP) -> SEXP;
     pub fn Rf_installNoTrChar(arg1: SEXP) -> SEXP;

--- a/bindings/bindings-windows-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.5-devel.rs
@@ -1728,8 +1728,6 @@ extern "C" {
     pub fn Rf_isPrimitive(arg1: SEXP) -> Rboolean;
     pub fn Rf_isTs(arg1: SEXP) -> Rboolean;
     pub fn Rf_isUserBinop(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidString(arg1: SEXP) -> Rboolean;
-    pub fn Rf_isValidStringF(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVector(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorAtomic(arg1: SEXP) -> Rboolean;
     pub fn Rf_isVectorList(arg1: SEXP) -> Rboolean;


### PR DESCRIPTION
R-devel is actively redefining what is, and what is not public API.

This PR applies the restrictions found here https://github.com/extendr/libR-sys/pull/252#issuecomment-2200273018.
Note that we are following @yutannihilation's advice here on `PRESEEN` and `SYMVALUE`. 

We broke the CI for bindings generation, so a manual update of the binding is necessary. See #251.