### PR TITLE
bindings: Remove remaining `Rf_isS4` and `R_altrep_Coerce_method_t` as we manually define those

### DIFF
--- a/bindings/bindings-linux-aarch64-R4.4-devel.rs
+++ b/bindings/bindings-linux-aarch64-R4.4-devel.rs
@@ -544,8 +544,6 @@ pub type R_altrep_DuplicateEX_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
 pub type R_altrep_Duplicate_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
-pub type R_altrep_Coerce_method_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: ::std::os::raw::c_int) -> SEXP>;
 pub type R_altrep_Inspect_method_t = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: SEXP,
@@ -1667,7 +1665,6 @@ extern "C" {
     pub fn R_tryEval(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_tryEvalSilent(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_GetCurrentEnv() -> SEXP;
-    pub fn Rf_isS4(arg1: SEXP) -> Rboolean;
     pub fn Rf_asS4(arg1: SEXP, arg2: Rboolean, arg3: ::std::os::raw::c_int) -> SEXP;
     pub fn Rf_S3Class(arg1: SEXP) -> SEXP;
     pub fn Rf_isBasicClass(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;

--- a/bindings/bindings-linux-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-linux-x86_64-R4.4-devel.rs
@@ -544,8 +544,6 @@ pub type R_altrep_DuplicateEX_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
 pub type R_altrep_Duplicate_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
-pub type R_altrep_Coerce_method_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: ::std::os::raw::c_int) -> SEXP>;
 pub type R_altrep_Inspect_method_t = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: SEXP,
@@ -1676,7 +1674,6 @@ extern "C" {
     pub fn R_tryEval(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_tryEvalSilent(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_GetCurrentEnv() -> SEXP;
-    pub fn Rf_isS4(arg1: SEXP) -> Rboolean;
     pub fn Rf_asS4(arg1: SEXP, arg2: Rboolean, arg3: ::std::os::raw::c_int) -> SEXP;
     pub fn Rf_S3Class(arg1: SEXP) -> SEXP;
     pub fn Rf_isBasicClass(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;

--- a/bindings/bindings-macos-x86_64-R4.3.rs
+++ b/bindings/bindings-macos-x86_64-R4.3.rs
@@ -591,8 +591,6 @@ pub type R_altrep_DuplicateEX_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
 pub type R_altrep_Duplicate_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
-pub type R_altrep_Coerce_method_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: ::std::os::raw::c_int) -> SEXP>;
 pub type R_altrep_Inspect_method_t = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: SEXP,
@@ -1730,7 +1728,6 @@ extern "C" {
     pub fn R_tryEval(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_tryEvalSilent(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_GetCurrentEnv() -> SEXP;
-    pub fn Rf_isS4(arg1: SEXP) -> Rboolean;
     pub fn Rf_asS4(arg1: SEXP, arg2: Rboolean, arg3: ::std::os::raw::c_int) -> SEXP;
     pub fn Rf_S3Class(arg1: SEXP) -> SEXP;
     pub fn Rf_isBasicClass(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;

--- a/bindings/bindings-macos-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.4-devel.rs
@@ -554,8 +554,6 @@ pub type R_altrep_DuplicateEX_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
 pub type R_altrep_Duplicate_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
-pub type R_altrep_Coerce_method_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: ::std::os::raw::c_int) -> SEXP>;
 pub type R_altrep_Inspect_method_t = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: SEXP,
@@ -1686,7 +1684,6 @@ extern "C" {
     pub fn R_tryEval(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_tryEvalSilent(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_GetCurrentEnv() -> SEXP;
-    pub fn Rf_isS4(arg1: SEXP) -> Rboolean;
     pub fn Rf_asS4(arg1: SEXP, arg2: Rboolean, arg3: ::std::os::raw::c_int) -> SEXP;
     pub fn Rf_S3Class(arg1: SEXP) -> SEXP;
     pub fn Rf_isBasicClass(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;

--- a/bindings/bindings-macos-x86_64-R4.5-devel.rs
+++ b/bindings/bindings-macos-x86_64-R4.5-devel.rs
@@ -592,8 +592,6 @@ pub type R_altrep_DuplicateEX_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
 pub type R_altrep_Duplicate_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
-pub type R_altrep_Coerce_method_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: ::std::os::raw::c_int) -> SEXP>;
 pub type R_altrep_Inspect_method_t = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: SEXP,
@@ -1718,7 +1716,6 @@ extern "C" {
     pub fn R_tryEval(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_tryEvalSilent(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_GetCurrentEnv() -> SEXP;
-    pub fn Rf_isS4(arg1: SEXP) -> Rboolean;
     pub fn Rf_asS4(arg1: SEXP, arg2: Rboolean, arg3: ::std::os::raw::c_int) -> SEXP;
     pub fn Rf_S3Class(arg1: SEXP) -> SEXP;
     pub fn Rf_isBasicClass(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;

--- a/bindings/bindings-windows-x86_64-R4.4-devel.rs
+++ b/bindings/bindings-windows-x86_64-R4.4-devel.rs
@@ -342,8 +342,6 @@ pub type R_altrep_DuplicateEX_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
 pub type R_altrep_Duplicate_method_t =
     ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: Rboolean) -> SEXP>;
-pub type R_altrep_Coerce_method_t =
-    ::std::option::Option<unsafe extern "C" fn(arg1: SEXP, arg2: ::std::os::raw::c_int) -> SEXP>;
 pub type R_altrep_Inspect_method_t = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: SEXP,
@@ -1466,7 +1464,6 @@ extern "C" {
     pub fn R_tryEval(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_tryEvalSilent(arg1: SEXP, arg2: SEXP, arg3: *mut ::std::os::raw::c_int) -> SEXP;
     pub fn R_GetCurrentEnv() -> SEXP;
-    pub fn Rf_isS4(arg1: SEXP) -> Rboolean;
     pub fn Rf_asS4(arg1: SEXP, arg2: Rboolean, arg3: ::std::os::raw::c_int) -> SEXP;
     pub fn Rf_S3Class(arg1: SEXP) -> SEXP;
     pub fn Rf_isBasicClass(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;


### PR DESCRIPTION
Somehow, these bindings was not removed from the cached bindings. I suspect our way of detecting `devel` might have been wonky, or a git merge went awry. 

Either case, here's a potential hotfix.