### PR TITLE
Stop updating bindings using CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ on:
   issue_comment:
     types:
       - created
-  # Run this once per three days
-  schedule:
-    - cron: '29 17 */3 * *'
   # This can also manually run
   workflow_dispatch: {}
 
@@ -228,25 +225,6 @@ jobs:
           ci-cargo test -vv $(if ($env:RUST_TARGET -ne '') {"--target=$env:RUST_TARGET"} ) '--' --nocapture -ActionName "Running bindgen tests for target: $env:RUST_TARGET"
         env:
           RUST_TARGET: ${{ matrix.config.target }}
-
-      # Build and emit bindings to './generated_bindings'
-      - name: Build & Emit bindings
-        id: build
-        run: |
-          . ./ci-cargo.ps1
-          # ci-cargo build -vv --features use-bindgen $(if ($env:RUST_TARGET -ne '') {"--target=$env:RUST_TARGET"} ) -ActionName "Building for target: $env:RUST_TARGET"
-        env:
-          LIBRSYS_BINDINGS_OUTPUT_PATH: generated_bindings
-          RUST_TARGET: ${{ matrix.config.target }}
-
-      - name: Upload generated bindings
-        if:
-          steps.build.outcome == 'success' &&
-          matrix.config.emit-bindings == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: generated_binding-${{ matrix.config.os }}-R-${{ matrix.config.r }}-rust-${{ matrix.config.rust-version }}-${{ matrix.config.target || 'default'}}
-          path: generated_bindings
   
   check_generate_bindings_flag:
     name: Check if [generate bindings] is in latest commit message


### PR DESCRIPTION
After https://github.com/extendr/libR-sys/pull/250, the scheduled execution of CI keep failing because it no longer emits bindings.

```
cp: cannot stat 'generated_binding-*/*.rs': No such file or directory
```
(https://github.com/extendr/libR-sys/actions/runs/10753234750/job/29822527827)

Whenever it fails (i.e. once per 3 days), GitHub emails me about the failure. I really don't know why GitHub blames me even after the HEAD commit of `master` is not mine. I know this is no one's fault, but this is quite annoying. So, I'd like to stop this by deleting the schedule. I think you can restore these lines when you get the generation of the bindings ready.